### PR TITLE
[Design] 이벤트/공지사항 페이지 푸터 위치 조정

### DIFF
--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -6,12 +6,13 @@ export default function MainLayout() {
   return (
     <div className="min-h-dvh bg-gray-100 text-knu-gray">
       <div className="mx-auto flex min-h-dvh w-full max-w-[700px] flex-col bg-white">
-        <main className="relative flex-1 min-h-0 px-5 pb-[calc(88px+env(safe-area-inset-bottom))]">
-          <Outlet />
-        </main>
-        <div className="pb-[calc(68px+env(safe-area-inset-bottom))]">
+        <main className="relative flex flex-col flex-1 min-h-0">
+          <div className="flex flex-col flex-1 px-5 min-h-dvh">
+            <Outlet />
+          </div>
           <Footer />
-        </div>
+          <div className="h-[calc(68px+env(safe-area-inset-bottom))]" />
+        </main>
         <BottomTabBar />
       </div>
     </div>

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -11,7 +11,7 @@ export default function MainLayout() {
             <Outlet />
           </div>
           <Footer />
-          <div className="h-[calc(68px+env(safe-area-inset-bottom))]" />
+          <div className="h-[calc(60px+env(safe-area-inset-bottom))]" />
         </main>
         <BottomTabBar />
       </div>

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -12,7 +12,7 @@ export default function EventPage() {
   );
 
   return (
-    <div className="pt-5 sm:p-5">
+    <div className="flex flex-col flex-1 pt-5 sm:p-5">
       <div className="flex items-center h-14">
         <img
           src={EventSvg}

--- a/src/pages/NoticeDetailPage.tsx
+++ b/src/pages/NoticeDetailPage.tsx
@@ -1,9 +1,13 @@
 import { useParams } from 'react-router-dom';
-import { FaRegCalendar, FaInfoCircle, FaUser } from 'react-icons/fa';
 import ImageCarousel from '@/components/ImageCarousel';
 import FoundItemCard from '@/components/FoundItemCard';
 import { useNoticeDetail } from '@/hooks/useNoticeDetail';
 import { toNoticeLabel } from '@/apis/enumMapper';
+import { StatusDisplay } from '@/components/StatusDisplay';
+import { PiSpinnerGapThin } from 'react-icons/pi';
+import { Badge } from '@/components/Badge';
+import { NOTICE_CATEGORY_COLOR_MAP } from '@/constants/notice';
+import { FaInfoCircle } from 'react-icons/fa';
 
 export default function NoticeDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -12,37 +16,49 @@ export default function NoticeDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-knu-red"></div>
+      <div className="flex flex-col items-center justify-center min-h-[80vh]">
+        <PiSpinnerGapThin className="h-12 w-12 animate-spin text-primary" />
       </div>
     );
   }
 
-  if (error || !notice) {
+  if (error) {
     return (
-      <div className="py-20 text-center text-gray-500">
-        공지사항을 불러오는 중 오류가 발생했거나 존재하지 않는 공지입니다.
+      <div className="flex flex-col items-center justify-center min-h-[80vh] px-5">
+        <StatusDisplay variant="error" title="인터넷 연결을 확인해주세요" />
+      </div>
+    );
+  }
+
+  if (!notice) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[80vh] px-5">
+        <StatusDisplay variant="error" title="해당 공지를 찾을 수 없습니다" />
       </div>
     );
   }
 
   const isLostItem = toNoticeLabel(notice.type) === '분실물';
+  const label = toNoticeLabel(notice.type);
+  const color = NOTICE_CATEGORY_COLOR_MAP[label as '공지' | '분실물'];
 
   return (
     <div className="pt-5">
-      <div className="flex flex-col space-y-1 mb-8 text-black">
-        <h2 className="typo-heading-3">{notice.title}</h2>
-        <div className="flex items-center space-x-4 text-sm text-gray-500 mt-1 pt-1">
-          <div className="flex items-center space-x-2">
-            <FaRegCalendar />
-            <span>작성일: {notice.createdAt.split('T')[0]}</span>
-          </div>
-          <span className="h-4 w-px bg-gray-300"></span>
-          <div className="flex items-center space-x-2">
-            <FaUser />
-            <span>작성자: {notice.authorNickname}</span>
-          </div>
+      <div className="flex flex-col space-y-1 mb-4 text-base-deep">
+        <div className="flex items-center gap-[8px] min-w-0">
+          <Badge className={`${color.badgeBg} ${color.badgeText} typo-body-2 font-medium`}>
+            {label}
+          </Badge>
+          <h2 className="typo-heading-3">{notice.title}</h2>
         </div>
+        <div className="flex items-center space-x-1 typo-body-3 text-gray-500 mt-1">
+          <span>{notice.authorNickname} ·</span>
+          <span>{notice.createdAt.split('T')[0]} 작성됨</span>
+        </div>
+      </div>
+
+      <div className="mb-10 mt-4 text-base-deep">
+        <p className="typo-body-2 whitespace-pre-wrap">{notice.content}</p>
       </div>
 
       {isLostItem && notice.lostFoundDetail && (
@@ -52,23 +68,23 @@ export default function NoticeDetailPage() {
         />
       )}
 
-      <div className="mb-10 mt-5 text-black">
-        <p className="typo-body-1 whitespace-pre-wrap">{notice.content}</p>
-      </div>
-
-      {notice.imageUrls && notice.imageUrls.length > 0 && (
-        <ImageCarousel
-          imageUrls={notice.imageUrls}
-          altText={`${notice.title} 관련 사진`}
-          label="관련 사진"
-          className="mb-10"
-        />
+      {isLostItem && (
+        <div className="mt-3 mb-10 flex p-3 items-center bg-primary/10 rounded-xl gap-2">
+          <FaInfoCircle className="text-primary shrink-0 w-4 h-4" />
+          <p className="typo-body-3 font-medium text-primary leading-tight">
+            분실물은 총동연 부스에서 수령할 수 있어요.
+          </p>
+        </div>
       )}
 
-      {isLostItem && (
-        <div className="flex items-center space-x-3 p-4 bg-red-50/50 border border-red-100 text-red-900 rounded-xl mb-10 shadow-sm">
-          <FaInfoCircle className="text-xl text-knu-red" />
-          <p className="typo-body-2 font-semibold">분실물은 총동연 부스에서 수령 가능합니다</p>
+      {notice.imageUrls && notice.imageUrls.length > 0 && (
+        <div className="mb-10">
+          <h3 className="typo-heading-4 mb-2 text-base-deep">관련 사진</h3>
+          <ImageCarousel
+            imageUrls={notice.imageUrls}
+            altText={`${notice.title} 사진`}
+            className="mb-10"
+          />
         </div>
       )}
     </div>

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -36,7 +36,7 @@ export default function NoticePage() {
   }, [selectedCategories, notices]);
 
   return (
-    <div className="flex flex-col gap-5 pt-5">
+    <div className="flex flex-col flex-1 gap-5 pt-5 sm:p-5">
       <div>
         <div className="flex items-center h-14 gap-2">
           <img


### PR DESCRIPTION
## 🔍 PR 요약

- 메인 레이아웃의 Flex 구조 개선 및 콘텐츠 영역(flex-1) 확장을 통해, 페이지 콘텐츠 양과 관계없이 푸터가 항상 화면 최하단(스크롤 시 노출)에 위치하도록 수정했습니다.

## 🧾 관련 이슈

- close #69 

## 🛠️ 주요 변경 사항

- 전체 레이아웃을 flex flex-col 구조로 변경하고 Outlet 감싸는 영역에 flex-1 및 min-h-dvh 적용
- Footer 컴포넌트 위치를 main 영역 내부 최하단으로 이동
- 고정된 BottomTabBar와의 겹침 방지를 위한 하단 스페이서(div) 추가
- EventPage와 NoticePage 페이지 간 패딩 스타일(pt-5 sm:p-5) 통일

## 🧠 의도 및 배경

- 기존에는 공지사항과 이벤트 페이지에서 콘텐츠 양이 적은 경우 푸터의 일부가 화면에 보이는 문제가 있었습니다. 이는 콘텐츠의 집중도를 낮출 수 있기에 스크롤을 끝까지 내렸을 때만 푸터를 확인할 수 있도록 하였습니다. 

