### PR TITLE
[FEAT] 메인페이지 공연 타임라인 연결

### DIFF
--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -11,6 +11,7 @@ export const ENDPOINTS = {
   noticeById: (noticeId: number | string) => `${PUBLIC_API_PREFIX}/notices/${noticeId}`,
   eventsByType: (eventType: EventType) => `${PUBLIC_API_PREFIX}/events/list/${eventType}`,
   eventById: (eventId: number | string) => `${PUBLIC_API_PREFIX}/events/${eventId}`,
+  performances: `${PUBLIC_API_PREFIX}/performances`,
   booths: `${PUBLIC_API_PREFIX}/booths/list`,
   boothCount: `${PUBLIC_API_PREFIX}/booths/count`,
   boothById: (boothId: number | string) => `${PUBLIC_API_PREFIX}/booths/${boothId}`,

--- a/src/apis/modules/performanceApi.ts
+++ b/src/apis/modules/performanceApi.ts
@@ -1,3 +1,7 @@
+import { ENDPOINTS } from '@/apis/endpoints';
+import { unwrapApiResponse } from '@/apis/error';
+import { http } from '@/apis/http';
+import type { ApiResponse } from '@/apis/types';
 import {
   PERFORMANCE_PREVIEW_BY_DAY,
   PERFORMANCE_TIMELINE_BY_DAY,
@@ -5,10 +9,83 @@ import {
   type PerformanceTimelineItem,
 } from '@/constants/performanceTimetable';
 
-export async function getPerformancePreviewByDay(day: DayKey): Promise<PerformanceTimelineItem[]> {
-  return PERFORMANCE_PREVIEW_BY_DAY[day];
+interface PerformanceResponseItem {
+  id: number;
+  date: string;
+  session: number;
+  startAt: string;
+  endAt: string;
+  boothId: number;
+  boothName: string;
+}
+
+const DAY_DATE_MAP: Record<DayKey, string> = {
+  day1: '2026-03-16',
+  day2: '2026-03-17',
+};
+
+function formatTimeRange(startAt: string, endAt: string): string {
+  const toTime = (value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  };
+
+  return `${toTime(startAt)}-${toTime(endAt)}`;
+}
+
+function toTimelineItem(item: PerformanceResponseItem): PerformanceTimelineItem {
+  return {
+    time: formatTimeRange(item.startAt, item.endAt),
+    title: item.boothName,
+    session: item.session,
+    location: '가두모집 중앙무대',
+    sessionLabel: `${item.session}회차`,
+    boothId: item.boothId,
+  };
+}
+
+function buildSessionPreview(items: PerformanceTimelineItem[]): PerformanceTimelineItem[] {
+  const bySession = new Map<number, PerformanceTimelineItem[]>();
+
+  items.forEach((item) => {
+    const list = bySession.get(item.session) ?? [];
+    list.push(item);
+    bySession.set(item.session, list);
+  });
+
+  return Array.from(bySession.values()).flatMap((sessionItems) => sessionItems.slice(0, 2));
+}
+
+async function getAllPerformances(): Promise<PerformanceResponseItem[]> {
+  const { data } = await http.get<ApiResponse<PerformanceResponseItem[]>>(ENDPOINTS.performances);
+  return unwrapApiResponse(data);
 }
 
 export async function getPerformanceTimelineByDay(day: DayKey): Promise<PerformanceTimelineItem[]> {
-  return PERFORMANCE_TIMELINE_BY_DAY[day];
+  try {
+    const apiItems = await getAllPerformances();
+    const timeline = apiItems
+      .filter((item) => item.date === DAY_DATE_MAP[day])
+      .sort((a, b) => {
+        if (a.session !== b.session) return a.session - b.session;
+        return new Date(a.startAt).getTime() - new Date(b.startAt).getTime();
+      })
+      .map(toTimelineItem);
+
+    return timeline.length > 0 ? timeline : PERFORMANCE_TIMELINE_BY_DAY[day];
+  } catch {
+    return PERFORMANCE_TIMELINE_BY_DAY[day];
+  }
+}
+
+export async function getPerformancePreviewByDay(day: DayKey): Promise<PerformanceTimelineItem[]> {
+  const timeline = await getPerformanceTimelineByDay(day);
+  if (timeline.length === 0) {
+    return PERFORMANCE_PREVIEW_BY_DAY[day];
+  }
+
+  return buildSessionPreview(timeline);
 }

--- a/src/apis/modules/performanceApi.ts
+++ b/src/apis/modules/performanceApi.ts
@@ -56,6 +56,10 @@ function buildSessionPreview(items: PerformanceTimelineItem[]): PerformanceTimel
     bySession.set(item.session, list);
   });
 
+  if (bySession.size === 1) {
+    return items.slice(0, 4);
+  }
+
   return Array.from(bySession.values()).flatMap((sessionItems) => sessionItems.slice(0, 2));
 }
 

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -149,6 +149,29 @@ function TimeTablePreviewCard({
 }) {
   const [showAll, setShowAll] = useState(false);
   const displayItems = showAll ? items : previewItems.slice(0, previewCount);
+  const groupedItems = useMemo(() => {
+    const map = new Map<
+      number,
+      {
+        sessionLabel: string;
+        items: PerformanceTimelineItem[];
+      }
+    >();
+
+    displayItems.forEach((item) => {
+      const current = map.get(item.session);
+      if (!current) {
+        map.set(item.session, { sessionLabel: item.sessionLabel, items: [item] });
+        return;
+      }
+      current.items.push(item);
+    });
+
+    return Array.from(map.entries()).map(([session, value]) => ({
+      session,
+      ...value,
+    }));
+  }, [displayItems]);
 
   return (
     <>
@@ -167,22 +190,53 @@ function TimeTablePreviewCard({
             })}
           </div>
         </div>
-        <div className="space-y-2">
-          {displayItems.length > 0 ? (
-            displayItems.map((item) => {
-              const color = SESSION_COLOR_MAP[item.session];
-              return (
-                <div
-                  key={`${item.time}-${item.title}`}
-                  className={`interactive-transition grid grid-cols-[90px_1fr] rounded-2xl px-5 py-4 ${color.bg} ${color.hoverBg}`}
-                >
-                  <p className={`typo-body-2 font-semibold ${color.text}`}>{item.time}</p>
-                  <div className="min-w-0">
-                    <p className="truncate typo-body-2 font-medium text-base-deep">{item.title}</p>
-                  </div>
-                </div>
-              );
-            })
+        <div className="space-y-3">
+          {groupedItems.length > 0 ? (
+            groupedItems.map((group) => (
+              <div key={group.session} className="space-y-2">
+                <p className="ml-1 typo-caption font-semibold text-text-muted">
+                  {group.sessionLabel}
+                </p>
+
+                {group.items.map((item) => {
+                  const color = SESSION_COLOR_MAP[item.session];
+                  const rowClassName = `interactive-transition grid grid-cols-[90px_1fr] rounded-2xl px-5 py-4 ${color.bg} ${color.hoverBg}`;
+
+                  const rowContent = (
+                    <>
+                      <p className={`typo-body-2 font-semibold ${color.text}`}>{item.time}</p>
+                      <div className="min-w-0">
+                        <p className="truncate typo-body-2 font-medium text-base-deep">
+                          {item.title}
+                        </p>
+                      </div>
+                    </>
+                  );
+
+                  if (item.boothId) {
+                    return (
+                      <Link
+                        key={`${item.session}-${item.time}-${item.boothId}`}
+                        to={`/booths/${item.boothId}`}
+                        className={rowClassName}
+                        aria-label={`${item.title} 부스 상세로 이동`}
+                      >
+                        {rowContent}
+                      </Link>
+                    );
+                  }
+
+                  return (
+                    <div
+                      key={`${item.session}-${item.time}-${item.title}`}
+                      className={rowClassName}
+                    >
+                      {rowContent}
+                    </div>
+                  );
+                })}
+              </div>
+            ))
           ) : (
             <div className="rounded-2xl bg-white/85 px-3 py-3 text-sm text-text-muted">
               등록된 타임테이블이 없습니다.
@@ -205,7 +259,7 @@ function TimeTablePreviewCard({
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        현장 상황에 따라 공연 시간이 일부 변경될 수 있어요
+        공연 카드를 누르면 해당 동아리 부스로 이동할 수 있어요
       </p>
     </>
   );
@@ -247,7 +301,7 @@ function NoticePreviewCard({ items }: { items: DayContent['noticePreview'] }) {
               );
             })
           ) : (
-            <div className="rounded-2xl bg-white px-3 py-3 text-sm text-text-muted">
+            <div className="rounded-2xl bg-white/85 px-3 py-3 text-sm text-text-muted">
               등록된 공지가 없습니다.
             </div>
           )}

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -217,9 +217,10 @@ function TimeTablePreviewCard({
                     return (
                       <Link
                         key={`${item.session}-${item.time}-${item.boothId}`}
-                        to={`/booths/${item.boothId}`}
+                        to="/map"
+                        state={{ selectedBoothId: item.boothId }}
                         className={rowClassName}
-                        aria-label={`${item.title} 부스 상세로 이동`}
+                        aria-label={`${item.title} 부스 위치로 이동`}
                       >
                         {rowContent}
                       </Link>
@@ -259,7 +260,7 @@ function TimeTablePreviewCard({
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        공연 카드를 누르면 해당 동아리 부스로 이동할 수 있어요
+        공연 카드를 누르면 해당 동아리의 지도 위치로 이동할 수 있어요
       </p>
     </>
   );

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -194,10 +194,6 @@ function TimeTablePreviewCard({
           {groupedItems.length > 0 ? (
             groupedItems.map((group) => (
               <div key={group.session} className="space-y-2">
-                <p className="ml-1 typo-caption font-semibold text-text-muted">
-                  {group.sessionLabel}
-                </p>
-
                 {group.items.map((item) => {
                   const color = SESSION_COLOR_MAP[item.session];
                   const rowClassName = `interactive-transition grid grid-cols-[90px_1fr] rounded-2xl px-5 py-4 ${color.bg} ${color.hoverBg}`;

--- a/src/constants/performanceTimetable.ts
+++ b/src/constants/performanceTimetable.ts
@@ -109,6 +109,17 @@ export const PERFORMANCE_TIMELINE_BY_DAY: Record<DayKey, PerformanceTimelineItem
 };
 
 function buildPreviewFromSets(sets: PerformanceSet[]): PerformanceTimelineItem[] {
+  if (sets.length === 1) {
+    const [set] = sets;
+    return set.items.slice(0, 4).map((item) => ({
+      time: item.time,
+      title: item.title,
+      session: set.session,
+      location: set.location,
+      sessionLabel: set.sessionLabel,
+    }));
+  }
+
   return sets.flatMap((set) =>
     set.items.slice(0, 2).map((item) => ({
       time: item.time,

--- a/src/constants/performanceTimetable.ts
+++ b/src/constants/performanceTimetable.ts
@@ -19,6 +19,7 @@ export type PerformanceTimelineItem = {
   session: number;
   location: string;
   sessionLabel: string;
+  boothId?: number;
 };
 
 export const PERFORMANCE_SETS_BY_DAY: Record<DayKey, PerformanceSet[]> = {

--- a/src/hooks/useRecommendedBooths.ts
+++ b/src/hooks/useRecommendedBooths.ts
@@ -1,29 +1,33 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { type BoothSummary, type BoothDivision } from '@/apis';
 
 const EXCLUDED_DIVISIONS: BoothDivision[] = ['MANAGEMENT', 'EXTERNAL_SUPPORT'];
 
+function pickRandomBooths(booths: BoothSummary[], count: number) {
+  if (booths.length <= count) {
+    return booths;
+  }
+
+  return [...booths].sort(() => Math.random() - 0.5).slice(0, count);
+}
+
 export function useRecommendedBooths(booths: BoothSummary[], count = 5, onlyActive = true) {
-  const [recommended] = useState<BoothSummary[]>(() => {
+  return useMemo(() => {
     if (booths.length === 0) return [];
     const candidates = onlyActive ? booths.filter((b) => b.isActive) : booths;
-    const shuffled = [...candidates].sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, count);
-  });
-
-  return recommended;
+    return pickRandomBooths(candidates, count);
+  }, [booths, count, onlyActive]);
 }
 
 export function useRecommendedClubBooths(booths: BoothSummary[], count = 5, onlyActive = true) {
-  if (booths.length === 0) return [];
+  return useMemo(() => {
+    if (booths.length === 0) return [];
 
-  let candidates = booths.filter((b) => !EXCLUDED_DIVISIONS.includes(b.division));
+    let candidates = booths.filter((b) => !EXCLUDED_DIVISIONS.includes(b.division));
+    if (onlyActive) {
+      candidates = candidates.filter((b) => b.isActive);
+    }
 
-  if (onlyActive) {
-    candidates = candidates.filter((b) => b.isActive);
-  }
-
-  const shuffled = [...candidates].sort(() => Math.random() - 0.5);
-
-  return shuffled.slice(0, count);
+    return pickRandomBooths(candidates, count);
+  }, [booths, count, onlyActive]);
 }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -16,7 +16,10 @@ export default function MapPage() {
   const [value, setValue] = useState('');
   const [selectedBoothId, setSelectedBoothId] = useState<number | null>(() => {
     const externalId = location.state?.selectedBoothId;
-    return externalId ? Number(externalId) : null;
+    if (externalId) return Number(externalId);
+
+    const queryId = new URLSearchParams(location.search).get('selectedBoothId');
+    return queryId ? Number(queryId) : null;
   });
 
   const [selectedDivision, setSelectedDivision] = useState<BoothDivision | null>(null);


### PR DESCRIPTION
## 🔍 PR 요약

메인 홈 탭의 공연 타임라인 동선을 개선하고, 지도 포커싱 연결 및 검색 추천 섹션 동작 이슈를 수정했습니다.  
또한 Day2 미리보기 노출 수와 타임라인 가이드 텍스트를 조정해 UX를 정리했습니다.

## 🧾 관련 이슈

- close #88

## 🛠️ 주요 변경 사항

- 공연 타임라인 카드 클릭 시 부스 상세(`/booths/:id`)가 아닌 지도(`/map`)로 이동하도록 변경
  - `selectedBoothId`를 전달해 지도에서 해당 부스를 바로 포커싱
- 지도 페이지에서 `selectedBoothId`를 `location.state` + query(`?selectedBoothId=`) 모두 지원하도록 보완
- Day2 공연 미리보기가 2개만 보이던 문제 수정
  - 세션이 1개인 경우 미리보기 4개 노출되도록 API/정적 fallback 로직 동기화
- 타임라인의 `1회차/2회차/3회차` 가이드 텍스트 제거
- 검색 페이지 “여기 방문은 어때요?” 추천 목록 갱신 이슈 수정
  - `useState` 초기화 기반 랜덤 추출 → `useMemo` 기반 재계산으로 변경
  - 부스 데이터 로드 후 추천 목록이 정상 노출되도록 개선

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

| 변경 전 | 변경 후 |
| --- | --- |
| 타임라인 카드 클릭 시 부스 상세 이동 | 타임라인 카드 클릭 시 지도 포커싱 이동 |
| Day2 미리보기 2개 노출 | Day2 미리보기 4개 노출 |
| 추천 목록이 비어 있거나 갱신 안됨 | 데이터 로드 후 추천 목록 정상 노출 |

## 🧠 의도 및 배경

- 공연 타임라인에서 사용자가 원하는 “부스 위치 확인” 동선을 바로 제공하기 위해 지도 포커싱 연결이 필요했습니다.
- Day2 미리보기 정보량 부족 및 회차 텍스트 중복 노출로 인한 가독성 이슈를 개선했습니다.
- 검색 추천 목록이 비정상적으로 비어 보이는 초기 렌더링 문제를 해결해 탐색 경험을 안정화했습니다.

## 💬 리뷰 요구사항(선택)

- 타임라인 카드 클릭 시 지도 포커싱 동선이 현재 UX 의도와 맞는지 확인 부탁드립니다.
- Day2 미리보기 4개 노출 기준(세션 1개일 때 4개)이 운영 의도와 맞는지 확인 부탁드립니다.
