### PR TITLE
[FIX] 에러 페이지 수정 및 메인페이지 텍스트 조정

### DIFF
--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -49,50 +49,12 @@ const DAY_CONTENT: Record<DayKey, DayContent> = {
   day1: {
     timetablePreview: PERFORMANCE_PREVIEW_BY_DAY.day1,
     timetableTimeline: PERFORMANCE_TIMELINE_BY_DAY.day1,
-    noticePreview: [
-      {
-        noticeId: undefined,
-        category: '공지',
-        title: '1일차 운영 시간 및 우천 시 안내',
-        date: '03.16',
-      },
-      {
-        noticeId: undefined,
-        category: '공지',
-        title: '백양로 일부 구간 동선 안내',
-        date: '03.16',
-      },
-      {
-        noticeId: undefined,
-        category: '분실물',
-        title: '현장 분실물 접수 위치 안내',
-        date: '03.16',
-      },
-    ],
+    noticePreview: [],
   },
   day2: {
     timetablePreview: PERFORMANCE_PREVIEW_BY_DAY.day2,
     timetableTimeline: PERFORMANCE_TIMELINE_BY_DAY.day2,
-    noticePreview: [
-      {
-        noticeId: undefined,
-        category: '공지',
-        title: '2일차 부스 위치 업데이트 안내',
-        date: '03.17',
-      },
-      {
-        noticeId: undefined,
-        category: '공지',
-        title: '프로그램 시간 변경 공지',
-        date: '03.17',
-      },
-      {
-        noticeId: undefined,
-        category: '분실물',
-        title: '분실물 보관 현황 업데이트',
-        date: '03.17',
-      },
-    ],
+    noticePreview: [],
   },
 };
 
@@ -230,15 +192,13 @@ function NoticePreviewCard({ items }: { items: DayContent['noticePreview'] }) {
                   aria-label={`${item.title} 상세 공지로 이동`}
                   className={`interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 ${color.bg} ${color.hoverBg} hover:border-knu-gold/60`}
                 >
-                  <div
-                    className={`interactive-transition grid grid-cols-[50px_1fr] rounded-2xl py-4}`}
-                  >
+                  <div className="interactive-transition grid min-w-0 grid-cols-[50px_1fr] items-center gap-2 rounded-2xl">
                     <p className={`typo-body-2 font-semibold ${color.text}`}>{item.date}</p>
-                    <div className="flex items-center gap-[6px]">
-                      <Badge className={`${color.badgeBg} ${color.badgeText}`}>
+                    <div className="flex min-w-0 items-center gap-[6px]">
+                      <Badge className={`shrink-0 ${color.badgeBg} ${color.badgeText}`}>
                         {item.category}
                       </Badge>
-                      <p className="truncate typo-body-2 font-medium text-base-deep">
+                      <p className="min-w-0 flex-1 truncate typo-body-2 font-medium text-base-deep">
                         {item.title}
                       </p>
                     </div>
@@ -345,11 +305,9 @@ export default function HomeTab() {
         if (!isMounted) return;
 
         const noticePreview = mapNoticesToPreview(notices);
-        const nextPreview =
-          noticePreview.length > 0 ? noticePreview : DAY_CONTENT.day1.noticePreview;
         setContentByDay((prev) => ({
-          day1: { ...prev.day1, noticePreview: nextPreview },
-          day2: { ...prev.day2, noticePreview: nextPreview },
+          day1: { ...prev.day1, noticePreview },
+          day2: { ...prev.day2, noticePreview },
         }));
       } catch {
         if (!isMounted) return;

--- a/src/components/map/world.ts
+++ b/src/components/map/world.ts
@@ -3,7 +3,7 @@ export const WORLD_HEIGHT = 3200;
 
 export const BUILDING_LABELS = [
   { name: '공대2A호관', x: 80, y: 440 },
-  { name: '공대2호관', x: 100, y: 840 },
+  { name: '공대2호관', x: 100, y: 940 },
   { name: '공대12호관', x: 164, y: 1560 },
   { name: 'IT대3호관', x: 120, y: 1850 },
   { name: 'IT대4호관', x: 120, y: 2016 },

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -49,7 +49,7 @@ export default function EventPage() {
           ))}
         </div>
       ) : (
-        <div className="flex flex-1 items-center justify-center rounded-2xl shadow-sm w-full min-h-45 border border-gray-200 bg-white ">
+        <div className="flex items-center justify-center rounded-2xl w-full min-h-10 border border-gray-200 bg-white ">
           <StatusDisplay variant="event" title="아직 예정된 이벤트가 없어요" />
         </div>
       )}

--- a/src/pages/NoticeDetailPage.tsx
+++ b/src/pages/NoticeDetailPage.tsx
@@ -45,12 +45,14 @@ export default function NoticeDetailPage() {
   return (
     <div className="pt-5">
       <div className="flex flex-col space-y-1 mb-4 text-base-deep">
-        <div className="flex items-center gap-[8px] min-w-0">
-          <Badge className={`${color.badgeBg} ${color.badgeText} typo-body-2 font-medium`}>
+        <h2 className="typo-heading-3 min-w-0 leading-tight break-words">
+          <Badge
+            className={`inline-flex align-middle mr-2 ${color.badgeBg} ${color.badgeText} typo-body-2 font-medium`}
+          >
             {label}
           </Badge>
-          <h2 className="typo-heading-3">{notice.title}</h2>
-        </div>
+          <span className="align-middle">{notice.title}</span>
+        </h2>
         <div className="flex items-center space-x-1 typo-body-3 text-gray-500 mt-1">
           <span>{notice.authorNickname} ·</span>
           <span>{notice.createdAt.split('T')[0]} 작성됨</span>

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -89,7 +89,7 @@ export default function NoticePage() {
             <StatusDisplay variant="error" title="인터넷 연결을 확인해주세요" onAction={refetch} />
           </div>
         ) : filteredNotices.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center rounded-2xl w-full min-h-45 border border-gray-200 bg-white">
+          <div className="flex items-center justify-center rounded-2xl w-full min-h-45 border border-gray-200 bg-white">
             <StatusDisplay variant="event" title="현재 등록된 공지사항이 없어요" />
           </div>
         ) : (


### PR DESCRIPTION
## 🔍 PR 요약

홈/공지/이벤트 화면에서 발견된 UI 이슈를 Hotfix로 정리했습니다.  
공지 미리보기 mock 데이터 제거, 긴 텍스트 truncation 보정, 이벤트/공지 빈 상태 UI 크기 보정, 공지 상세 타이틀-뱃지 정렬 개선을 포함합니다.

## 🧾 관련 이슈

- close #88

## 🛠️ 주요 변경 사항

- `src/components/home/HomeTab.tsx`
  - 공지 미리보기의 day1/day2 mock 데이터 제거 (`noticePreview: []`)
  - 최근 공지 API 응답을 그대로 사용하도록 fallback 정리
  - 공지 미리보기 카드 긴 텍스트 truncation 보정
    - `min-w-0`, `flex-1`, `shrink-0` 적용으로 배지/제목 레이아웃 안정화

- `src/pages/EventPage.tsx`
  - 이벤트 페이지 에러/빈 상태 컨테이너 높이 축소 (과도한 세로 영역 개선)

- `src/pages/NoticePage.tsx`
  - 공지 페이지 빈 상태 영역의 불필요한 `flex-1` 제거로 정렬 일관성 보정

- `src/pages/NoticeDetailPage.tsx`
  - 제목과 뱃지를 동일 행 흐름으로 정렬
  - 제목이 길어질 때 텍스트가 배지 아래로 자연스럽게 이어지도록 구조 조정

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

| 변경 전 | 변경 후 |
| --- | --- |
| 홈 공지 미리보기에서 mock 내용 노출 가능 | API 데이터만 노출 |
| 공지 미리보기 긴 제목 시 배지/텍스트 간격 깨짐 | 긴 제목도 안정적으로 truncation |
| 이벤트 페이지 에러 상태 UI가 과도하게 큼 | 컴팩트한 크기로 정리 |
| 공지 상세 제목이 길 때 배지 위치 어색 | 배지+제목 동일 흐름으로 정렬 |

## 🧠 의도 및 배경

- 운영 중 사용자에게 노출되는 정보의 일관성과 정확도를 확보하기 위해 mock 기반 fallback을 제거했습니다.
- 긴 텍스트(특히 공지 제목)에서 발생하던 UI 깨짐을 정리해 가독성과 안정성을 개선했습니다.
- 상태 UI(에러/빈 데이터) 크기를 서비스 톤에 맞게 조정해 화면 밀도와 시각적 균형을 맞췄습니다.

## 💬 리뷰 요구사항(선택)

- 홈 공지 미리보기/공지 상세에서 긴 제목 케이스 UI 확인 부탁드립니다.
- 이벤트/공지 빈 상태 컨테이너 높이가 모바일 뷰에서 적절한지 확인 부탁드립니다.
