### PR TITLE
[FIX] axios-retry 도입 및 Sentry 노이즈 에러 무시 설정

### DIFF
--- a/instrument.ts
+++ b/instrument.ts
@@ -9,5 +9,7 @@ if (isProd) {
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 1.0,
     tracePropagationTargets: ['localhost', import.meta.env.VITE_API_BASE_URL],
+
+    ignoreErrors: ['Java object is gone', 'Error invoking postMessage', 'Request aborted'],
   });
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@sentry/react": "^10.42.0",
     "@vercel/analytics": "^1.6.1",
     "axios": "^1.13.6",
+    "axios-retry": "^4.5.0",
     "framer-motion": "^12.34.0",
     "posthog-js": "^1.360.1",
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       axios:
         specifier: ^1.13.6
         version: 1.13.6
+      axios-retry:
+        specifier: ^4.5.0
+        version: 4.5.0(axios@1.13.6)
       framer-motion:
         specifier: ^12.34.0
         version: 12.35.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -614,13 +617,6 @@ packages:
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
 
-  '@playwright/test@1.58.2':
-    resolution:
-      {
-        integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==,
-      }
-    engines: { node: '>=18' }
-    hasBin: true
   '@opentelemetry/api-logs@0.208.0':
     resolution:
       {
@@ -731,6 +727,14 @@ packages:
         integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==,
       }
     engines: { node: '>=14' }
+
+  '@playwright/test@1.58.2':
+    resolution:
+      {
+        integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
 
   '@posthog/core@1.23.3':
     resolution:
@@ -1701,6 +1705,14 @@ packages:
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
+  axios-retry@4.5.0:
+    resolution:
+      {
+        integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==,
+      }
+    peerDependencies:
+      axios: 0.x || 1.x
+
   axios@1.13.6:
     resolution:
       {
@@ -2374,6 +2386,13 @@ packages:
         integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
       }
     engines: { node: '>=0.10.0' }
+
+  is-retry-allowed@2.2.0:
+    resolution:
+      {
+        integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==,
+      }
+    engines: { node: '>=10' }
 
   isexe@2.0.0:
     resolution:
@@ -3576,9 +3595,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@playwright/test@1.58.2':
-    dependencies:
-      playwright: 1.58.2
   '@opentelemetry/api-logs@0.208.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -3654,6 +3670,10 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@posthog/core@1.23.3':
     dependencies:
@@ -4212,6 +4232,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios-retry@4.5.0(axios@1.13.6):
+    dependencies:
+      axios: 1.13.6
+      is-retry-allowed: 2.2.0
+
   axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
@@ -4609,6 +4634,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-retry-allowed@2.2.0: {}
 
   isexe@2.0.0: {}
 

--- a/src/apis/http.ts
+++ b/src/apis/http.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios';
 import posthog from 'posthog-js';
+import axiosRetry from 'axios-retry';
 
 import { clearAccessToken, getAccessToken } from './auth';
 import { toApiClientError } from './error';
@@ -15,6 +16,20 @@ export const http = axios.create({
   timeout: timeoutMs,
   headers: {
     Accept: 'application/json',
+  },
+});
+
+axiosRetry(http, {
+  retries: 3,
+  shouldResetTimeout: true,
+  retryDelay: (retryCount) => {
+    return axiosRetry.exponentialDelay(retryCount);
+  },
+  retryCondition: (error) => {
+    return (
+      axiosRetry.isNetworkOrIdempotentRequestError(error) ||
+      (error.response ? error.response.status >= 500 : false)
+    );
   },
 });
 


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 버그 수정 (네트워크 에러 및 인앱 브라우저 대응)

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #102 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- axios-retry 라이브러리 도입
- 네트워크 단절 및 타임아웃 발생 시 최대 3회 자동 재시도 로직 추가
- 지수 백오프(Exponential Backoff) 적용으로 안정적인 재연결 시도
- Sentry 설정 최적화
- 인앱 브라우저(카톡, 인스타) 전용 버그(Java object is gone) 무시 설정
- 사용자의 의도적인 페이지 이탈로 인한 Request aborted 에러 필터링
- pnpm 환경 최적화
- pnpm-lock.yaml 포맷 수정 및 의존성 추가

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 문제상황) iOS/Android 인앱 브라우저 및 불안정한 네트워크 환경에서 API 호출 시 즉시 에러가 발생하여 사용자 이탈 유발
- 해결방안) axios-retry를 통한 자동 재시도로 일시적 장애를 극복하고, Sentry 로그의 노이즈(인앱 브라우저 고유 버그 등)를 제거하여 실제 크리티컬한 에러에 집중할 수 있는 환경을 구축함.
