### PR TITLE
[FEAT] TanStack Query 도입 및 useBooths 캐싱 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@posthog/react": "^1.8.2",
     "@sentry/react": "^10.42.0",
+    "@tanstack/react-query": "^5.90.21",
     "@vercel/analytics": "^1.6.1",
     "axios": "^1.13.6",
     "axios-retry": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@sentry/react':
         specifier: ^10.42.0
         version: 10.43.0(react@19.2.4)
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@19.2.4)
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(react@19.2.4)
@@ -1335,6 +1338,20 @@ packages:
       }
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.90.20':
+    resolution:
+      {
+        integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==,
+      }
+
+  '@tanstack/react-query@5.90.21':
+    resolution:
+      {
+        integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==,
+      }
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution:
@@ -3972,6 +3989,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.21(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.4
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/hooks/useBooths.ts
+++ b/src/hooks/useBooths.ts
@@ -1,23 +1,13 @@
-import { useState, useEffect } from 'react';
-import { getBooths, type BoothListParams, type BoothSummary } from '@/apis';
+import { useQuery } from '@tanstack/react-query';
+import { getBooths, type BoothListParams } from '@/apis';
 
 export function useBooths(params?: BoothListParams) {
-  const [booths, setBooths] = useState<BoothSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  const keyword = params?.keyword;
 
-  useEffect(() => {
-    const fetchBooths = async () => {
-      try {
-        setLoading(true);
-        const data = await getBooths(params);
-        setBooths(data);
-      } finally {
-        setLoading(false);
-      }
-    };
+  return useQuery({
+    queryKey: keyword ? ['booths', 'search', keyword] : ['booths', 'all'],
+    queryFn: () => getBooths(params),
 
-    fetchBooths();
-  }, [params]);
-
-  return { booths, loading };
+    staleTime: 1000 * 60 * 5,
+  });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { PostHogProvider } from '@posthog/react';
 import './index.css';
 import App from './App.tsx';
 import * as Sentry from '@sentry/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const isProd = import.meta.env.MODE === 'production';
 
@@ -24,11 +25,15 @@ const root = createRoot(container!, {
   }),
 });
 
+const queryClient = new QueryClient();
+
 root.render(
   <StrictMode>
     <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={posthogOptions}>
       <BrowserRouter>
-        <App />
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
       </BrowserRouter>
     </PostHogProvider>
   </StrictMode>,

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -11,7 +11,7 @@ import type { BoothDivision } from '@/apis';
 export default function MapPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { booths } = useBooths();
+  const { data: booths = [] } = useBooths();
 
   const [value, setValue] = useState('');
   const [selectedBoothId, setSelectedBoothId] = useState<number | null>(() => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -10,7 +10,7 @@ import { RECOMMENDATIONS } from '@/constants/booth';
 export default function SearchPage() {
   const navigate = useNavigate();
   const [, setSearchParams] = useSearchParams();
-  const { booths } = useBooths();
+  const { data: booths = [] } = useBooths();
   const recommendedBooths = useRecommendedBooths(booths, 5);
 
   const [value, setValue] = useState('');

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -5,20 +5,18 @@ import { BoothItem } from '@/components/BoothItem';
 import { StatusDisplay } from '@/components/StatusDisplay';
 import { useBooths } from '@/hooks/useBooths';
 import { useRecommendedClubBooths } from '@/hooks/useRecommendedBooths';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 export default function SearchResultPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get('q') || '';
   const [searchTerm, setSearchTerm] = useState(query);
   const navigate = useNavigate();
-  const paramsMemo = useMemo(() => ({ keyword: query }), [query]);
-  const { booths } = useBooths(paramsMemo);
-  const { booths: allBooths } = useBooths();
+  const { data: searchResults = [] } = useBooths({ keyword: query });
+  const { data: allBooths = [] } = useBooths();
   const recommendedBooths = useRecommendedClubBooths(allBooths, 5);
 
-  const results = Object.values(booths);
-  const hasResults = results.length > 0;
+  const hasResults = searchResults.length > 0;
   const isSearching = query !== '';
 
   return (
@@ -45,10 +43,10 @@ export default function SearchResultPage() {
         {hasResults ? (
           <div className="px-1 py-4">
             <p className="typo-body-2 text-gray-500 mb-4">
-              총 <span className="text-black font-medium">{results.length}개</span>의 결과
+              총 <span className="text-black font-medium">{searchResults.length}개</span>의 결과
             </p>
             <div className="flex flex-col gap-5">
-              {results.map((booth) => (
+              {searchResults.map((booth) => (
                 <BoothItem
                   key={booth.id}
                   booth={booth}


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- TanStack Query(React Query) 도입을 통한 서버 데이터 관리 및 API 캐싱 최적화

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #105 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- TanStack Query 도입: @tanstack/react-query를 통한 전역 서버 상태 관리 시스템 구축
- useBooths 훅에 staleTime(5분)을 설정하여 지도-검색 페이지 이동 시 불필요한 중복 API 호출 제거
- 검색어(keyword) 유무에 따른 queryKey 분리로 검색 결과와 전체 리스트 캐시 독립 관리

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 서버 부하 감소: 축제 피크 타임 시 급증할 수 있는 리스트 조회 트래픽을 클라이언트 단에서 캐싱하여 서버 리소스를 보호함
- 코드 품질: 수동으로 관리하던 useState, useEffect 기반의 비동기 로직을 선언적인 TanStack Query 훅으로 대체하여 가독성 및 유지보수성 향상
