### PR TITLE
[FEAT] 메인 페이지 인기 동아리 랭킹 UI 추가 및 상세 페이지 내 위치보기 연동을 통한 사용자 UX 개선

### DIFF
--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -17,6 +17,7 @@ export const ENDPOINTS = {
   boothById: (boothId: number | string) => `${PUBLIC_API_PREFIX}/booths/${boothId}`,
   boothLikes: (boothId: number | string) => `${PUBLIC_API_PREFIX}/booths/${boothId}/likes`,
   boothRanking: `${PUBLIC_API_PREFIX}/booths/ranking`,
+  boothTop3: `${PUBLIC_API_PREFIX}/booths/ranking/top3`,
 
   // Admin (token required)
   adminMe: `${ADMIN_API_PREFIX}/me`,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -60,12 +60,16 @@ export {
   getBooths,
   getBoothCount,
   getBooth,
+  getBoothTop3,
+  getBoothRanking,
   updateBooth,
   type BoothDivision,
   type BoothMutationInput,
   type BoothSummary,
   type BoothListParams,
   type BoothUpdateInput,
+  type BoothRanking,
+  type Booth3Ranking,
 } from '@/apis/modules/boothApi';
 export {
   getAdminProfile,

--- a/src/apis/modules/boothApi.ts
+++ b/src/apis/modules/boothApi.ts
@@ -44,6 +44,12 @@ export interface BoothRanking {
   likeCount: number;
 }
 
+export interface Booth3Ranking {
+  boothId: number;
+  boothName: string;
+  likeCount: number;
+}
+
 export interface BoothMutationInput {
   memberId: number;
   boothNumber: number;
@@ -161,6 +167,12 @@ export async function likeBooth(boothId: number): Promise<number> {
 
 export async function getBoothRanking(): Promise<BoothRanking[]> {
   const { data } = await http.get<ApiResponse<BoothRanking[]>>(ENDPOINTS.boothRanking);
+
+  return unwrapApiResponse(data);
+}
+
+export async function getBoothTop3(): Promise<Booth3Ranking[]> {
+  const { data } = await http.get<ApiResponse<Booth3Ranking[]>>(ENDPOINTS.boothTop3);
 
   return unwrapApiResponse(data);
 }

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { FiChevronRight, FiAlertCircle, FiChevronDown } from 'react-icons/fi';
 import MapSvg from '@/assets/map.svg';
 import {
@@ -17,10 +17,12 @@ import {
   SESSION_COLOR_MAP,
 } from '@/constants/performanceTimetable';
 import { SelectableButton } from '../SelectableButton';
+import { useBoothTop3 } from '@/hooks/useBoothTop3';
 import { useBoothCount } from '@/hooks/useBoothCount';
 import { toMonthDayDot } from '@/lib/date';
 import { NOTICE_CATEGORY_COLOR_MAP } from '@/constants/notice';
 import { Badge } from '../Badge';
+import { FaStar } from 'react-icons/fa';
 
 type DayOption = {
   key: DayKey;
@@ -73,6 +75,57 @@ type SectionHeaderProps = {
   description?: React.ReactNode;
   to?: string;
 };
+
+function TrendingBooths() {
+  const { data: ranking, isLoading } = useBoothTop3();
+  const navigate = useNavigate();
+
+  if (isLoading) {
+    return (
+      <div className="flex gap-2 justify-center items-center h-[96px] px-1">
+        <div className="flex-1 w-[120px] h-[96px] bg-gray-100 animate-pulse rounded-xl" />
+        <div className="flex-1 w-[120px] h-[96px] bg-gray-100 animate-pulse rounded-xl" />
+        <div className="flex-1 w-[120px] h-[96px] bg-gray-100 animate-pulse rounded-xl" />
+      </div>
+    );
+  }
+
+  if (!ranking || ranking.length === 0) return null;
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-center gap-2 px-1 relative z-20">
+        {ranking.slice(0, 3).map((booth, index) => {
+          const rank = index + 1;
+          return (
+            <button
+              key={booth.boothId}
+              onClick={() => navigate(`/booths/${booth.boothId}`)}
+              className={`relative flex flex-col w-[120px] py-3 items-center justify-center gap-1 rounded-xl bg-secondary-yellow/10 transition-all active:scale-95`}
+            >
+              <div className="flex items-center justify-center gap-1">
+                <span className={`typo-body-1 font-semibold text-base-deep `}>{rank}위</span>
+              </div>
+              <p className="text-center typo-body-2 font-medium line-clamp-2 text-base-deep flex items-center justify-center">
+                {booth.boothName}
+              </p>
+              <div className="flex items-center gap-0.5">
+                <FaStar className="text-secondary-yellow w-4 h-4" />
+                <span className="text-secondary-yellow typo-body-3 font-semibold">
+                  {booth.likeCount.toLocaleString()}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
+        <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
+        카드를 눌러 동아리 정보를 확인할 수 있어요
+      </p>
+    </div>
+  );
+}
 
 function SectionHeader({ title, text, description, to }: SectionHeaderProps) {
   return (
@@ -403,6 +456,10 @@ export default function HomeTab() {
         aria-labelledby={`home-day-tab-${activeDay}`}
         className="space-y-14 pt-10"
       >
+        <section aria-labelledby="home-timetable-title">
+          <SectionHeader title="지금 뜨는 동아리" description="투표로 동아리를 응원해보세요" />
+          <TrendingBooths />
+        </section>
         <section aria-labelledby="home-timetable-title">
           <SectionHeader title="공연시간표" description="일청담 앞 중앙무대에서 만나요" />
           <TimeTablePreviewCard

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -271,7 +271,7 @@ function TimeTablePreviewCard({
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        공연 카드를 누르면 해당 동아리의 지도 위치로 이동할 수 있어요
+        카드를 눌러 동아리 위치를 확인할 수 있어요
       </p>
     </>
   );

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -77,10 +77,12 @@ type SectionHeaderProps = {
 };
 
 function TrendingBooths() {
-  const { data: ranking, isLoading } = useBoothTop3();
+  const { data: ranking, status } = useBoothTop3();
   const navigate = useNavigate();
 
-  if (isLoading) {
+  const isFirstLoading = status === 'pending' && (!ranking || ranking.length === 0);
+
+  if (isFirstLoading) {
     return (
       <div className="flex gap-2 justify-center items-center h-[96px] px-1">
         <div className="flex-1 w-[120px] h-[96px] bg-gray-100 animate-pulse rounded-xl" />

--- a/src/hooks/useBoothTop3.ts
+++ b/src/hooks/useBoothTop3.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { getBoothTop3, type Booth3Ranking } from '@/apis';
+
+export function useBoothTop3() {
+  const [data, setData] = useState<Booth3Ranking[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchRanking = async () => {
+      setIsLoading(true);
+      try {
+        const res = await getBoothTop3();
+        if (isMounted) setData(res);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    };
+
+    fetchRanking();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { data, isLoading };
+}

--- a/src/hooks/useBoothTop3.ts
+++ b/src/hooks/useBoothTop3.ts
@@ -1,31 +1,17 @@
-import { useState, useEffect } from 'react';
-import { getBoothTop3, type Booth3Ranking } from '@/apis';
+import { useQuery } from '@tanstack/react-query';
+import { getBoothTop3 } from '@/apis';
 
 export function useBoothTop3() {
-  const [data, setData] = useState<Booth3Ranking[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, status } = useQuery({
+    queryKey: ['booths', 'ranking', 'top3'],
+    queryFn: getBoothTop3,
+    staleTime: 0,
+    gcTime: 1000 * 60 * 2,
+  });
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchRanking = async () => {
-      setIsLoading(true);
-      try {
-        const res = await getBoothTop3();
-        if (isMounted) setData(res);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        if (isMounted) setIsLoading(false);
-      }
-    };
-
-    fetchRanking();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return { data, isLoading };
+  return {
+    data: data ?? [],
+    isLoading,
+    status,
+  };
 }

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { getBoothRanking, type BoothRanking } from '@/apis/modules/boothApi';
+import { getBoothRanking, type BoothRanking } from '@/apis';
 
 export function useRanking() {
   const [booths, setBooths] = useState<BoothRanking[]>([]);

--- a/src/pages/BoothDetailPage.tsx
+++ b/src/pages/BoothDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useState } from 'react';
 import ImageCarousel from '@/components/ImageCarousel';
 import ApplyButton from '@/components/ApplyButton';
@@ -112,7 +112,20 @@ export default function BoothDetailPage() {
           </p>
         </div>
       </div>
-      {booth.applyLink && !isSpecialDivision && <ApplyButton url={booth.applyLink} />}
+      <div className="flex gap-3 mb-10">
+        <Link
+          to="/map"
+          state={{ selectedBoothId: booth.id }}
+          className="flex-1 flex items-center justify-center bg-gray-100 rounded-full text-base-deep py-3 mb-6 typo-body-1 cursor-pointer transition-all hover:scale-[1.01] hover:brightness-95 active:scale-[0.98]"
+        >
+          위치보기
+        </Link>
+        {!isSpecialDivision && booth.applyLink && (
+          <div className="flex-1">
+            <ApplyButton url={booth.applyLink} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 예: 로그인 API 구현 및 세션 미들웨어 추가

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #104

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- useBoothTop3 훅에 React Query를 적용하여 데이터 캐싱 및 백그라운드 갱신
- status === 'pending' 조건을 활용하여 재진입 시 레이아웃 깜빡임 제거
- 부스 상세 페이지 하단에 위치보기 버튼 추가 (지도 페이지로 state 전달)

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- UX 최적화: 단순히 데이터를 보여주는 것을 넘어, 리액트 쿼리의 캐싱 기능을 활용해 유저가 체감하는 로딩 속도를 타임테이블 컴포넌트 수준으로 끌어올리고자 함
- 서비스 연결성 강화: 상세 페이지에서 해당 부스의 위치를 즉시 확인할 수 있도록 함
