### PR TITLE
[FEAT] 서비스 종료 시간 접근 제한 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,9 @@ import RankingPage from '@/pages/RankingPage';
 import RankingLayout from './components/layouts/RankingLayout';
 import GoogleAnalytics from '@/utils/GoogleAnalytics';
 
+import MaintenancePage from '@/pages/MaintenancePage';
+import { isMaintenanceTime } from '@/lib/maintenance';
+
 const SPLASH_DURATION_MS = 1500;
 const isAdminRoutePath = (pathname: string) =>
   pathname === '/admin' || pathname.startsWith('/admin/');
@@ -43,6 +46,8 @@ export default function App() {
   const posthog = usePostHog();
   const bootstrapSession = useAdminSessionStore((state) => state.bootstrapSession);
   const setUnauthenticated = useAdminSessionStore((state) => state.setUnauthenticated);
+
+  const isMaintenance = isMaintenanceTime();
 
   useEffect(() => {
     if (posthog) {
@@ -82,6 +87,10 @@ export default function App() {
       setUnauthorizedHandler(null);
     };
   }, [location.hash, location.pathname, location.search, navigate, setUnauthenticated]);
+
+  if (isMaintenance) {
+    return <MaintenancePage />;
+  }
 
   if (isLoading) {
     return <SplashScreen />;

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -1,0 +1,7 @@
+export function isMaintenanceTime(): boolean {
+  const now = new Date();
+  const start = new Date('2026-03-16T20:00:00+09:00');
+  const end = new Date('2026-03-17T07:00:00+09:00');
+
+  return now >= start && now < end;
+}

--- a/src/pages/MaintenancePage.tsx
+++ b/src/pages/MaintenancePage.tsx
@@ -1,0 +1,13 @@
+import { StatusDisplay } from '@/components/StatusDisplay';
+
+export default function MaintenancePage() {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-white px-10">
+      <StatusDisplay
+        variant="maintenance"
+        title="내일 다시 만나요!"
+        description={`가두모집 운영 시간이 종료되었습니다.\n내일 오전 7시에 다시 만나요!`}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔍 PR 요약

- 서비스 운영 종료 시간(20:00 ~ 07:00) 동안 사용자의 접근을 차단하고 안내 페이지를 노출합니다.

## 🧾 관련 이슈

- close #107 

## 🛠️ 주요 변경 사항

- src/lib/maintenance.ts 추가: 한국 시간(KST) 기준 점검 시간 여부를 판별하는 유틸리티 함수 구현
- StatusDisplay 컴포넌트를 재사용하여 "내일 봐요!" 안내 화면 구현
- src/App.tsx 수정:
  - isMaintenanceTime 결과에 따른 조건부 렌더링 적용
  - 점검 시 Routes 상위에 가드를 배치하여 모든 하위 컴포넌트의 렌더링 및 API 요청 차단

## 🧠 의도 및 배경

- 가두모집 운영 종료 후 불필요한 서버 요청을 방지하여 서버 자원을 효율적으로 관리하기 위함입니다.
- API 응답 대기 없이 클라이언트 사이드에서 즉각적으로 안내 페이지를 보여주도록 설계하여 사용자 경험을 개선했습니다.
