### PR TITLE
[HOTFIX] 더블 스타 팝업 날짜/시간 조건 오노출 수정

### DIFF
--- a/src/components/home/LikeBoostPopup.tsx
+++ b/src/components/home/LikeBoostPopup.tsx
@@ -1,26 +1,13 @@
 import { useEffect, useState } from 'react';
 import { FiX, FiClock, FiMapPin, FiStar } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
-
-type LikeBoostStatus = 'upcoming' | 'active' | 'ended';
+import { getLikeBoostStatus, type LikeBoostStatus } from '@/constants/likeBoostEvent';
 
 type LikeBoostPopupProps = {
   isOpen: boolean;
   onClose: () => void;
   onHideToday: () => void;
 };
-
-function getLikeBoostStatus(now: Date): LikeBoostStatus {
-  const start = new Date(now);
-  start.setHours(13, 0, 0, 0);
-
-  const end = new Date(now);
-  end.setHours(15, 0, 0, 0);
-
-  if (now < start) return 'upcoming';
-  if (now >= start && now < end) return 'active';
-  return 'ended';
-}
 
 const STATUS_COPY: Record<
   LikeBoostStatus,

--- a/src/constants/likeBoostEvent.ts
+++ b/src/constants/likeBoostEvent.ts
@@ -1,0 +1,36 @@
+export type LikeBoostStatus = 'upcoming' | 'active' | 'ended';
+
+export const LIKE_BOOST_EVENT_DATE = '2026-03-16';
+export const LIKE_BOOST_START_HOUR = 13;
+export const LIKE_BOOST_END_HOUR = 15;
+
+function toDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function isLikeBoostEventDay(date: Date): boolean {
+  return toDateKey(date) === LIKE_BOOST_EVENT_DATE;
+}
+
+export function getLikeBoostStatus(date: Date): LikeBoostStatus {
+  if (!isLikeBoostEventDay(date)) {
+    return 'ended';
+  }
+
+  const start = new Date(date);
+  start.setHours(LIKE_BOOST_START_HOUR, 0, 0, 0);
+
+  const end = new Date(date);
+  end.setHours(LIKE_BOOST_END_HOUR, 0, 0, 0);
+
+  if (date < start) return 'upcoming';
+  if (date >= start && date < end) return 'active';
+  return 'ended';
+}
+
+export function isLikeBoostPopupAvailable(date: Date): boolean {
+  return getLikeBoostStatus(date) !== 'ended';
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,23 +3,13 @@ import HomeBanner from '@/components/home/HomeBanner';
 import HomeTab from '@/components/home/HomeTab';
 import LikeBoostPopup from '@/components/home/LikeBoostPopup';
 import FaceSvg from '@/assets/face.svg';
-
-function getTodayKey() {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function isLikeBoostPopupAvailable(now: Date) {
-  const end = new Date(now);
-  end.setHours(15, 0, 0, 0);
-  return now < end;
-}
+import { LIKE_BOOST_EVENT_DATE, isLikeBoostPopupAvailable } from '@/constants/likeBoostEvent';
 
 export default function HomePage() {
-  const dismissStorageKey = useMemo(() => `like-boost-popup-dismissed-${getTodayKey()}`, []);
+  const dismissStorageKey = useMemo(
+    () => `like-boost-popup-dismissed-${LIKE_BOOST_EVENT_DATE}`,
+    [],
+  );
   const [isPopupOpen, setIsPopupOpen] = useState(() => {
     if (typeof window === 'undefined') return false;
     if (!isLikeBoostPopupAvailable(new Date())) return false;


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 더블 스타 이벤트 팝업이 이벤트 다음날에도 노출되던 문제를 수정했습니다.
- 팝업 노출/상태 계산 로직을 날짜+시간 기준으로 정리해 오노출을 방지했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #88

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- `src/constants/likeBoostEvent.ts` 신설
  - 이벤트 날짜 상수(`2026-03-16`) 추가
  - 팝업 상태 계산 함수(`getLikeBoostStatus`) 추가
  - 팝업 노출 가능 여부 함수(`isLikeBoostPopupAvailable`) 추가
- `src/pages/HomePage.tsx`
  - 팝업 초기 노출 조건을 날짜+시간 기준으로 변경
  - dismiss storage key를 이벤트 날짜 기준으로 고정
- `src/components/home/LikeBoostPopup.tsx`
  - 내부 상태 판별 로직을 공통 유틸 사용으로 통일

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

- UI 변경보다는 노출 조건/동작 로직 수정이 중심입니다.

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 기존 구현은 시간대(13:00~15:00)만 기준으로 팝업을 표시해 이벤트일이 아닌 날에도 오노출 가능성이 있었습니다.
- 이벤트성 안내는 특정 날짜에만 보여야 하므로 날짜 조건을 포함한 상태 관리가 필요했습니다.
- 공통 유틸로 기준을 통합해 HomePage/Popup 간 판별 불일치를 제거했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 다음 이벤트 때는 `likeBoostEvent.ts`의 날짜 상수만 변경하면 재사용 가능한 구조인지 확인 부탁드립니다.
- 이벤트 종료 후(15:00 이후) 팝업 미노출 동작이 의도대로인지 QA 확인 부탁드립니다.
