### PR TITLE
[Release] 가두모집 서비스 v1.2.5 프로덕션 배포

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knu-client",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.5",
   "type": "module",
   "packageManager": "pnpm@9.15.3",
   "scripts": {

--- a/src/components/home/LikeBoostPopup.tsx
+++ b/src/components/home/LikeBoostPopup.tsx
@@ -1,26 +1,13 @@
 import { useEffect, useState } from 'react';
 import { FiX, FiClock, FiMapPin, FiStar } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
-
-type LikeBoostStatus = 'upcoming' | 'active' | 'ended';
+import { getLikeBoostStatus, type LikeBoostStatus } from '@/constants/likeBoostEvent';
 
 type LikeBoostPopupProps = {
   isOpen: boolean;
   onClose: () => void;
   onHideToday: () => void;
 };
-
-function getLikeBoostStatus(now: Date): LikeBoostStatus {
-  const start = new Date(now);
-  start.setHours(13, 0, 0, 0);
-
-  const end = new Date(now);
-  end.setHours(15, 0, 0, 0);
-
-  if (now < start) return 'upcoming';
-  if (now >= start && now < end) return 'active';
-  return 'ended';
-}
 
 const STATUS_COPY: Record<
   LikeBoostStatus,

--- a/src/constants/likeBoostEvent.ts
+++ b/src/constants/likeBoostEvent.ts
@@ -1,0 +1,36 @@
+export type LikeBoostStatus = 'upcoming' | 'active' | 'ended';
+
+export const LIKE_BOOST_EVENT_DATE = '2026-03-16';
+export const LIKE_BOOST_START_HOUR = 13;
+export const LIKE_BOOST_END_HOUR = 15;
+
+function toDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function isLikeBoostEventDay(date: Date): boolean {
+  return toDateKey(date) === LIKE_BOOST_EVENT_DATE;
+}
+
+export function getLikeBoostStatus(date: Date): LikeBoostStatus {
+  if (!isLikeBoostEventDay(date)) {
+    return 'ended';
+  }
+
+  const start = new Date(date);
+  start.setHours(LIKE_BOOST_START_HOUR, 0, 0, 0);
+
+  const end = new Date(date);
+  end.setHours(LIKE_BOOST_END_HOUR, 0, 0, 0);
+
+  if (date < start) return 'upcoming';
+  if (date >= start && date < end) return 'active';
+  return 'ended';
+}
+
+export function isLikeBoostPopupAvailable(date: Date): boolean {
+  return getLikeBoostStatus(date) !== 'ended';
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,23 +3,13 @@ import HomeBanner from '@/components/home/HomeBanner';
 import HomeTab from '@/components/home/HomeTab';
 import LikeBoostPopup from '@/components/home/LikeBoostPopup';
 import FaceSvg from '@/assets/face.svg';
-
-function getTodayKey() {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function isLikeBoostPopupAvailable(now: Date) {
-  const end = new Date(now);
-  end.setHours(15, 0, 0, 0);
-  return now < end;
-}
+import { LIKE_BOOST_EVENT_DATE, isLikeBoostPopupAvailable } from '@/constants/likeBoostEvent';
 
 export default function HomePage() {
-  const dismissStorageKey = useMemo(() => `like-boost-popup-dismissed-${getTodayKey()}`, []);
+  const dismissStorageKey = useMemo(
+    () => `like-boost-popup-dismissed-${LIKE_BOOST_EVENT_DATE}`,
+    [],
+  );
   const [isPopupOpen, setIsPopupOpen] = useState(() => {
     if (typeof window === 'undefined') return false;
     if (!isLikeBoostPopupAvailable(new Date())) return false;


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.
- HOTFIX: 더블 스타 팝업 날짜/시간 조건 오노출 수정 (#112)

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 더블 스타 이벤트 팝업이 이벤트 다음날에도 노출되던 문제를 수정했습니다.
- 팝업 노출/상태 계산 로직을 날짜+시간 기준으로 정리해 오노출을 방지했습니다.