### PR TITLE
[FEAT] 랭킹 페이지 전날 TOP3 팝업(서버 API 기반) 도입

### DIFF
--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -18,7 +18,7 @@ export const ENDPOINTS = {
   boothLikes: (boothId: number | string) => `${PUBLIC_API_PREFIX}/booths/${boothId}/likes`,
   boothRanking: `${PUBLIC_API_PREFIX}/booths/ranking`,
   boothTop3: `${PUBLIC_API_PREFIX}/booths/ranking/top3`,
-  boothTop3Yesterday: `${PUBLIC_API_PREFIX}/booths/ranking/top3/yesterday`,
+  boothDailyRanking: (date: string) => `${PUBLIC_API_PREFIX}/booths/ranking/daily/${date}`,
 
   // Admin (token required)
   adminMe: `${ADMIN_API_PREFIX}/me`,

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -18,6 +18,7 @@ export const ENDPOINTS = {
   boothLikes: (boothId: number | string) => `${PUBLIC_API_PREFIX}/booths/${boothId}/likes`,
   boothRanking: `${PUBLIC_API_PREFIX}/booths/ranking`,
   boothTop3: `${PUBLIC_API_PREFIX}/booths/ranking/top3`,
+  boothTop3Yesterday: `${PUBLIC_API_PREFIX}/booths/ranking/top3/yesterday`,
 
   // Admin (token required)
   adminMe: `${ADMIN_API_PREFIX}/me`,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -61,6 +61,7 @@ export {
   getBoothCount,
   getBooth,
   getBoothTop3,
+  getYesterdayBoothTop3,
   getBoothRanking,
   updateBooth,
   type BoothDivision,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -61,7 +61,7 @@ export {
   getBoothCount,
   getBooth,
   getBoothTop3,
-  getYesterdayBoothTop3,
+  getBoothDailyRanking,
   getBoothRanking,
   updateBooth,
   type BoothDivision,

--- a/src/apis/modules/boothApi.ts
+++ b/src/apis/modules/boothApi.ts
@@ -177,8 +177,8 @@ export async function getBoothTop3(): Promise<Booth3Ranking[]> {
   return unwrapApiResponse(data);
 }
 
-export async function getYesterdayBoothTop3(): Promise<Booth3Ranking[]> {
-  const { data } = await http.get<ApiResponse<Booth3Ranking[]>>(ENDPOINTS.boothTop3Yesterday);
+export async function getBoothDailyRanking(date: string): Promise<BoothRanking[]> {
+  const { data } = await http.get<ApiResponse<BoothRanking[]>>(ENDPOINTS.boothDailyRanking(date));
 
   return unwrapApiResponse(data);
 }

--- a/src/apis/modules/boothApi.ts
+++ b/src/apis/modules/boothApi.ts
@@ -176,3 +176,9 @@ export async function getBoothTop3(): Promise<Booth3Ranking[]> {
 
   return unwrapApiResponse(data);
 }
+
+export async function getYesterdayBoothTop3(): Promise<Booth3Ranking[]> {
+  const { data } = await http.get<ApiResponse<Booth3Ranking[]>>(ENDPOINTS.boothTop3Yesterday);
+
+  return unwrapApiResponse(data);
+}

--- a/src/components/home/LikeBoostPopup.tsx
+++ b/src/components/home/LikeBoostPopup.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
 import { FiX, FiClock, FiMapPin, FiStar } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
-import { getLikeBoostStatus, type LikeBoostStatus } from '@/constants/likeBoostEvent';
+import {
+  LIKE_BOOST_END_HOUR,
+  LIKE_BOOST_START_HOUR,
+  getLikeBoostStatus,
+  type LikeBoostStatus,
+} from '@/constants/likeBoostEvent';
 
 type LikeBoostPopupProps = {
   isOpen: boolean;
@@ -16,7 +21,7 @@ const STATUS_COPY: Record<
   upcoming: {
     badge: '곧 시작',
     badgeClassName: 'bg-secondary-blue/10 text-secondary-blue',
-    description: '13:00부터 15:00까지 스타 1회 클릭 시 2개가 반영돼요.',
+    description: '곧 더블 스타 타임이 시작됩니다.',
   },
   active: {
     badge: '진행 중',
@@ -29,6 +34,12 @@ const STATUS_COPY: Record<
     description: '오늘 더블 스타 이벤트는 종료됐어요. 일반 스타로 참여할 수 있어요.',
   },
 };
+
+function formatHourRange(startHour: number, endHour: number): string {
+  const start = String(startHour).padStart(2, '0');
+  const end = String(endHour).padStart(2, '0');
+  return `${start}:00 ~ ${end}:00`;
+}
 
 export default function LikeBoostPopup({ isOpen, onClose, onHideToday }: LikeBoostPopupProps) {
   const navigate = useNavigate();
@@ -48,6 +59,7 @@ export default function LikeBoostPopup({ isOpen, onClose, onHideToday }: LikeBoo
   }, [isOpen]);
 
   const status = getLikeBoostStatus(new Date());
+  const timeRange = formatHourRange(LIKE_BOOST_START_HOUR, LIKE_BOOST_END_HOUR);
   const copy = STATUS_COPY[status];
 
   const handleClose = () => {
@@ -99,7 +111,7 @@ export default function LikeBoostPopup({ isOpen, onClose, onHideToday }: LikeBoo
           </span>
           <span className="inline-flex items-center gap-1 text-gray-500 typo-body-3">
             <FiClock className="h-3.5 w-3.5" />
-            13:00 ~ 15:00
+            {timeRange}
           </span>
         </div>
 

--- a/src/constants/likeBoostEvent.ts
+++ b/src/constants/likeBoostEvent.ts
@@ -1,8 +1,8 @@
 export type LikeBoostStatus = 'upcoming' | 'active' | 'ended';
 
-export const LIKE_BOOST_EVENT_DATE = '2026-03-16';
-export const LIKE_BOOST_START_HOUR = 13;
-export const LIKE_BOOST_END_HOUR = 15;
+export const LIKE_BOOST_EVENT_DATE = '2026-03-17';
+export const LIKE_BOOST_START_HOUR = 12;
+export const LIKE_BOOST_END_HOUR = 14;
 
 function toDateKey(date: Date): string {
   const year = date.getFullYear();

--- a/src/hooks/useLikeBooth.ts
+++ b/src/hooks/useLikeBooth.ts
@@ -1,11 +1,36 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { likeBooth } from '@/apis/modules/boothApi';
+
+const CLIENT_LIKE_COOLDOWN_MS = 1000;
 
 export function useLikeBooth(boothId: number) {
   const [isPending, setIsPending] = useState(false);
+  const [cooldownUntil, setCooldownUntil] = useState(0);
+
+  const isCoolingDown = cooldownUntil > Date.now();
+
+  useEffect(() => {
+    if (cooldownUntil <= Date.now()) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCooldownUntil(0);
+    }, cooldownUntil - Date.now());
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [cooldownUntil]);
 
   const mutate = useCallback(async () => {
-    if (isPending) return;
+    if (isPending) return undefined;
+
+    if (cooldownUntil > Date.now()) {
+      return undefined;
+    }
+
+    setCooldownUntil(Date.now() + CLIENT_LIKE_COOLDOWN_MS);
     setIsPending(true);
 
     try {
@@ -17,7 +42,7 @@ export function useLikeBooth(boothId: number) {
     } finally {
       setIsPending(false);
     }
-  }, [boothId, isPending]);
+  }, [boothId, cooldownUntil, isPending]);
 
-  return { mutate, isPending };
+  return { mutate, isPending, isCoolingDown };
 }

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,124 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { getBoothRanking, type BoothRanking } from '@/apis';
-
-const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
-const RANKING_LATEST_KEY = 'ranking:latest';
-const RANKING_ROTATED_ON_KEY = 'ranking:last-rotated-date';
-const RANKING_DAILY_PREFIX = 'ranking:snapshot:';
-
-interface RankingSnapshot {
-  date: string;
-  capturedAt: string;
-  booths: BoothRanking[];
-}
-
-interface RankingPartition {
-  topThree: BoothRanking[];
-  rest: BoothRanking[];
-}
-
-function getKstDateKey(dayOffset = 0, now = new Date()): string {
-  const kstTime = now.getTime() + KST_OFFSET_MS + dayOffset * DAY_MS;
-  const kstDate = new Date(kstTime);
-
-  const year = kstDate.getUTCFullYear();
-  const month = String(kstDate.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(kstDate.getUTCDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
-}
-
-function getDailySnapshotKey(dateKey: string): string {
-  return `${RANKING_DAILY_PREFIX}${dateKey}`;
-}
-
-function readSnapshot(storageKey: string): RankingSnapshot | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const rawValue = window.localStorage.getItem(storageKey);
-  if (!rawValue) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(rawValue) as RankingSnapshot;
-    if (!parsed || typeof parsed.date !== 'string' || !Array.isArray(parsed.booths)) {
-      return null;
-    }
-
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function readDailySnapshot(dateKey: string): RankingSnapshot | null {
-  return readSnapshot(getDailySnapshotKey(dateKey));
-}
-
-function readLatestSnapshot(): RankingSnapshot | null {
-  return readSnapshot(RANKING_LATEST_KEY);
-}
-
-function persistLatestSnapshot(booths: BoothRanking[]): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const snapshot: RankingSnapshot = {
-    date: getKstDateKey(),
-    capturedAt: new Date().toISOString(),
-    booths,
-  };
-
-  window.localStorage.setItem(RANKING_LATEST_KEY, JSON.stringify(snapshot));
-}
-
-function rotateYesterdaySnapshotIfNeeded(): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const today = getKstDateKey();
-  const yesterday = getKstDateKey(-1);
-  const lastRotatedDate = window.localStorage.getItem(RANKING_ROTATED_ON_KEY);
-
-  if (lastRotatedDate === today) {
-    return;
-  }
-
-  const latest = readLatestSnapshot();
-  if (latest && latest.date === yesterday) {
-    window.localStorage.setItem(getDailySnapshotKey(yesterday), JSON.stringify(latest));
-  }
-
-  window.localStorage.setItem(RANKING_ROTATED_ON_KEY, today);
-}
-
-function partitionRanking(booths: BoothRanking[]): RankingPartition {
-  const topThree = [booths[1], booths[0], booths[2]].filter((item): item is BoothRanking =>
-    Boolean(item),
-  );
-  const rest = booths.slice(3);
-
-  return { topThree, rest };
-}
 
 export function useRanking() {
   const [booths, setBooths] = useState<BoothRanking[]>([]);
-  const [yesterdayBooths, setYesterdayBooths] = useState<BoothRanking[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [yesterdayDateKey] = useState(() => getKstDateKey(-1));
 
   const fetchRanking = async () => {
     try {
       setIsLoading(true);
       const data = await getBoothRanking();
       setBooths(data);
-      persistLatestSnapshot(data);
     } catch (error) {
       console.error('랭킹 로드 실패:', error);
     } finally {
@@ -127,42 +18,16 @@ export function useRanking() {
   };
 
   useEffect(() => {
-    let isMounted = true;
-
-    rotateYesterdaySnapshotIfNeeded();
-
-    void Promise.resolve().then(() => {
-      if (!isMounted) {
-        return;
-      }
-
-      const snapshot = readDailySnapshot(yesterdayDateKey);
-      setYesterdayBooths(snapshot?.booths ?? []);
-    });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [yesterdayDateKey]);
-
-  useEffect(() => {
-    void fetchRanking();
+    fetchRanking();
   }, []);
 
-  const today = useMemo(() => {
-    return partitionRanking(booths);
+  const { topThree, rest } = useMemo(() => {
+    const podium = [booths[1], booths[0], booths[2]].filter(Boolean);
+
+    const rest = booths.slice(3);
+
+    return { topThree: podium, rest };
   }, [booths]);
 
-  const yesterday = useMemo(() => {
-    return partitionRanking(yesterdayBooths);
-  }, [yesterdayBooths]);
-
-  return {
-    today,
-    yesterday,
-    yesterdayDateKey,
-    hasYesterdaySnapshot: yesterdayBooths.length > 0,
-    isLoading,
-    refetch: fetchRanking,
-  };
+  return { topThree, rest, isLoading, refetch: fetchRanking };
 }

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,15 +1,124 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getBoothRanking, type BoothRanking } from '@/apis';
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RANKING_LATEST_KEY = 'ranking:latest';
+const RANKING_ROTATED_ON_KEY = 'ranking:last-rotated-date';
+const RANKING_DAILY_PREFIX = 'ranking:snapshot:';
+
+interface RankingSnapshot {
+  date: string;
+  capturedAt: string;
+  booths: BoothRanking[];
+}
+
+interface RankingPartition {
+  topThree: BoothRanking[];
+  rest: BoothRanking[];
+}
+
+function getKstDateKey(dayOffset = 0, now = new Date()): string {
+  const kstTime = now.getTime() + KST_OFFSET_MS + dayOffset * DAY_MS;
+  const kstDate = new Date(kstTime);
+
+  const year = kstDate.getUTCFullYear();
+  const month = String(kstDate.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(kstDate.getUTCDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function getDailySnapshotKey(dateKey: string): string {
+  return `${RANKING_DAILY_PREFIX}${dateKey}`;
+}
+
+function readSnapshot(storageKey: string): RankingSnapshot | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(storageKey);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as RankingSnapshot;
+    if (!parsed || typeof parsed.date !== 'string' || !Array.isArray(parsed.booths)) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function readDailySnapshot(dateKey: string): RankingSnapshot | null {
+  return readSnapshot(getDailySnapshotKey(dateKey));
+}
+
+function readLatestSnapshot(): RankingSnapshot | null {
+  return readSnapshot(RANKING_LATEST_KEY);
+}
+
+function persistLatestSnapshot(booths: BoothRanking[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const snapshot: RankingSnapshot = {
+    date: getKstDateKey(),
+    capturedAt: new Date().toISOString(),
+    booths,
+  };
+
+  window.localStorage.setItem(RANKING_LATEST_KEY, JSON.stringify(snapshot));
+}
+
+function rotateYesterdaySnapshotIfNeeded(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const today = getKstDateKey();
+  const yesterday = getKstDateKey(-1);
+  const lastRotatedDate = window.localStorage.getItem(RANKING_ROTATED_ON_KEY);
+
+  if (lastRotatedDate === today) {
+    return;
+  }
+
+  const latest = readLatestSnapshot();
+  if (latest && latest.date === yesterday) {
+    window.localStorage.setItem(getDailySnapshotKey(yesterday), JSON.stringify(latest));
+  }
+
+  window.localStorage.setItem(RANKING_ROTATED_ON_KEY, today);
+}
+
+function partitionRanking(booths: BoothRanking[]): RankingPartition {
+  const topThree = [booths[1], booths[0], booths[2]].filter((item): item is BoothRanking =>
+    Boolean(item),
+  );
+  const rest = booths.slice(3);
+
+  return { topThree, rest };
+}
 
 export function useRanking() {
   const [booths, setBooths] = useState<BoothRanking[]>([]);
+  const [yesterdayBooths, setYesterdayBooths] = useState<BoothRanking[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [yesterdayDateKey] = useState(() => getKstDateKey(-1));
 
   const fetchRanking = async () => {
     try {
       setIsLoading(true);
       const data = await getBoothRanking();
       setBooths(data);
+      persistLatestSnapshot(data);
     } catch (error) {
       console.error('랭킹 로드 실패:', error);
     } finally {
@@ -18,16 +127,42 @@ export function useRanking() {
   };
 
   useEffect(() => {
-    fetchRanking();
+    let isMounted = true;
+
+    rotateYesterdaySnapshotIfNeeded();
+
+    void Promise.resolve().then(() => {
+      if (!isMounted) {
+        return;
+      }
+
+      const snapshot = readDailySnapshot(yesterdayDateKey);
+      setYesterdayBooths(snapshot?.booths ?? []);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [yesterdayDateKey]);
+
+  useEffect(() => {
+    void fetchRanking();
   }, []);
 
-  const { topThree, rest } = useMemo(() => {
-    const podium = [booths[1], booths[0], booths[2]].filter(Boolean);
-
-    const rest = booths.slice(3);
-
-    return { topThree: podium, rest };
+  const today = useMemo(() => {
+    return partitionRanking(booths);
   }, [booths]);
 
-  return { topThree, rest, isLoading, refetch: fetchRanking };
+  const yesterday = useMemo(() => {
+    return partitionRanking(yesterdayBooths);
+  }, [yesterdayBooths]);
+
+  return {
+    today,
+    yesterday,
+    yesterdayDateKey,
+    hasYesterdaySnapshot: yesterdayBooths.length > 0,
+    isLoading,
+    refetch: fetchRanking,
+  };
 }

--- a/src/hooks/useYesterdayBoothTop3.ts
+++ b/src/hooks/useYesterdayBoothTop3.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { getYesterdayBoothTop3 } from '@/apis';
+
+export function useYesterdayBoothTop3() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['booths', 'ranking', 'top3', 'yesterday'],
+    queryFn: getYesterdayBoothTop3,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+
+  return {
+    data: data ?? [],
+    isLoading,
+    isError,
+  };
+}

--- a/src/hooks/useYesterdayBoothTop3.ts
+++ b/src/hooks/useYesterdayBoothTop3.ts
@@ -1,16 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
-import { getYesterdayBoothTop3 } from '@/apis';
+import { getBoothDailyRanking } from '@/apis';
+
+function getDateKey(dayOffset = 0): string {
+  const now = new Date();
+  const date = new Date(now);
+  date.setDate(date.getDate() + dayOffset);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
 
 export function useYesterdayBoothTop3() {
+  const yesterdayDate = getDateKey(-1);
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['booths', 'ranking', 'top3', 'yesterday'],
-    queryFn: getYesterdayBoothTop3,
+    queryKey: ['booths', 'ranking', 'daily', yesterdayDate],
+    queryFn: async () => {
+      const ranking = await getBoothDailyRanking(yesterdayDate);
+      return ranking.slice(0, 3);
+    },
     staleTime: 1000 * 60 * 5,
     retry: 1,
   });
 
   return {
     data: data ?? [],
+    date: yesterdayDate,
     isLoading,
     isError,
   };

--- a/src/pages/BoothDetailPage.tsx
+++ b/src/pages/BoothDetailPage.tsx
@@ -16,19 +16,16 @@ export default function BoothDetailPage() {
   const { id } = useParams<{ id: string }>();
   const boothId = Number(id);
   const [bursts, setBursts] = useState<{ id: string; x: number; y: number }[]>([]);
-
   const [likeDelta, setLikeDelta] = useState(0);
 
-  const { mutate, isPending } = useLikeBooth(boothId);
+  const { mutate, isPending, isCoolingDown } = useLikeBooth(boothId);
   const { booth, loading, refetch } = useBooth(boothId);
   const displayLikeCount = (booth?.likeCount ?? 0) + likeDelta;
 
   const isSpecialDivision =
     booth?.division === 'MANAGEMENT' || booth?.division === 'EXTERNAL_SUPPORT';
 
-  const handleStarClick = async () => {
-    if (isPending) return;
-
+  const createStarBurst = () => {
     const newBurst = {
       id: crypto.randomUUID(),
       x: Math.random() * 100 - 50,
@@ -39,18 +36,19 @@ export default function BoothDetailPage() {
     setTimeout(() => {
       setBursts((prev) => prev.filter((b) => b.id !== newBurst.id));
     }, 1000);
+  };
 
-    setLikeDelta((prev) => (prev ?? 0) + 1);
+  const handleStarClick = async () => {
+    if (isPending || isCoolingDown) return;
 
     try {
       const updatedCount = await mutate();
-
-      if (updatedCount !== undefined) {
+      if (typeof updatedCount === 'number') {
         setLikeDelta(updatedCount - (booth?.likeCount ?? 0));
+        createStarBurst();
       }
     } catch (error) {
       console.error('좋아요 실패:', error);
-      setLikeDelta((prev) => prev - 1);
     }
   };
 
@@ -82,7 +80,7 @@ export default function BoothDetailPage() {
         {!isSpecialDivision && (
           <button
             onClick={handleStarClick}
-            disabled={isPending}
+            disabled={isPending || isCoolingDown}
             className="flex cursor-pointer items-center justify-center rounded-full gap-[2px] bg-white transition-all hover:brightness-95 active:scale-[0.98]"
           >
             <PiShootingStarFill size={28} className="text-secondary-yellow" />

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -22,7 +22,11 @@ function getTodayKey() {
 
 export default function RankingPage() {
   const { topThree, rest, isLoading } = useRanking();
-  const { data: yesterdayTop3, isLoading: isYesterdayTop3Loading } = useYesterdayBoothTop3();
+  const {
+    data: yesterdayTop3,
+    date: yesterdayDate,
+    isLoading: isYesterdayTop3Loading,
+  } = useYesterdayBoothTop3();
 
   const dismissStorageKey = useMemo(() => `ranking-yesterday-top3-dismissed-${getTodayKey()}`, []);
 
@@ -163,18 +167,15 @@ export default function RankingPage() {
         })}
       </section>
 
-      {(hasYesterdayTop3 || isYesterdayTop3Loading) && (
-        <button
-          type="button"
-          onClick={() => setIsPopupOpenedByButton(true)}
-          disabled={!hasYesterdayTop3 && isYesterdayTop3Loading}
-          aria-label="어제 TOP3 팝업 열기"
-          className="fixed bottom-[calc(88px+env(safe-area-inset-bottom))] right-5 z-40 inline-flex h-12 items-center justify-center gap-1 rounded-full bg-primary px-4 text-white shadow-[0_10px_22px_rgba(230,0,0,0.28)] transition hover:brightness-95 active:scale-95 disabled:cursor-not-allowed disabled:opacity-70"
-        >
-          <FaStar className="h-4 w-4" />
-          <span className="typo-body-3 font-semibold">어제 TOP3</span>
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => setIsPopupOpenedByButton(true)}
+        aria-label="어제 TOP3 팝업 열기"
+        className="fixed bottom-[calc(88px+env(safe-area-inset-bottom))] right-5 z-40 inline-flex h-12 items-center justify-center gap-1 rounded-full bg-primary px-4 text-white shadow-[0_10px_22px_rgba(230,0,0,0.28)] transition hover:brightness-95 active:scale-95"
+      >
+        <FaStar className="h-4 w-4" />
+        <span className="typo-body-3 font-semibold">어제 TOP3</span>
+      </button>
 
       {isYesterdayPopupOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-5">
@@ -201,31 +202,43 @@ export default function RankingPage() {
             </button>
 
             <h2 className="typo-heading-3 text-base-deep">어제 TOP3 관심 동아리였습니다</h2>
-            <p className="mt-1 typo-body-3 text-gray-500">오늘도 많은 참여 부탁드릴게요!</p>
+            <p className="mt-1 typo-body-3 text-gray-500">
+              {yesterdayDate} 기준 결과예요. 오늘도 많은 참여 부탁드릴게요!
+            </p>
 
-            <div className="mt-4 space-y-2">
-              {yesterdayTop3.map((booth, index) => (
-                <Link
-                  key={booth.boothId}
-                  to={`/booths/${booth.boothId}`}
-                  onClick={handleCloseYesterdayPopup}
-                  className="interactive-transition flex items-center justify-between rounded-2xl border border-knu-silver/60 bg-knu-silver/10 px-4 py-3 hover:border-knu-red/25 hover:bg-knu-red/5"
-                >
-                  <div className="min-w-0">
-                    <p className="typo-body-3 font-semibold text-knu-red">{index + 1}위</p>
-                    <p className="truncate typo-body-2 font-medium text-base-deep">
-                      {booth.boothName}
-                    </p>
-                  </div>
-                  <div className="ml-3 flex items-center gap-1">
-                    <FaStar className="text-secondary-yellow" />
-                    <span className="typo-body-3 font-semibold text-base-deep">
-                      {formatLikeCount(booth.likeCount)}
-                    </span>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            {isYesterdayTop3Loading ? (
+              <div className="mt-4 rounded-2xl border border-knu-silver/50 bg-knu-silver/10 px-4 py-6 text-center text-sm text-text-muted">
+                어제 TOP3를 불러오는 중이에요.
+              </div>
+            ) : yesterdayTop3.length === 0 ? (
+              <div className="mt-4 rounded-2xl border border-knu-silver/50 bg-knu-silver/10 px-4 py-6 text-center text-sm text-text-muted">
+                어제 TOP3 데이터가 아직 없습니다.
+              </div>
+            ) : (
+              <div className="mt-4 space-y-2">
+                {yesterdayTop3.map((booth, index) => (
+                  <Link
+                    key={booth.boothId}
+                    to={`/booths/${booth.boothId}`}
+                    onClick={handleCloseYesterdayPopup}
+                    className="interactive-transition flex items-center justify-between rounded-2xl border border-knu-silver/60 bg-knu-silver/10 px-4 py-3 hover:border-knu-red/25 hover:bg-knu-red/5"
+                  >
+                    <div className="min-w-0">
+                      <p className="typo-body-3 font-semibold text-knu-red">{index + 1}위</p>
+                      <p className="truncate typo-body-2 font-medium text-base-deep">
+                        {booth.name}
+                      </p>
+                    </div>
+                    <div className="ml-3 flex items-center gap-1">
+                      <FaStar className="text-secondary-yellow" />
+                      <span className="typo-body-3 font-semibold text-base-deep">
+                        {formatLikeCount(booth.likeCount)}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
 
             <div className="mt-5 grid grid-cols-2 gap-2">
               <button

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { PiSpinnerGapThin } from 'react-icons/pi';
 import { FaStar } from 'react-icons/fa';
@@ -10,12 +10,33 @@ import FaceSilverSvg from '@/assets/face-silver.svg';
 import FaceBronzeSvg from '@/assets/face-bronze.svg';
 import { formatLikeCount } from '@/lib/count';
 
+type RankingTab = 'today' | 'yesterday';
+
+function formatMonthDay(dateKey: string): string {
+  const [, month, day] = dateKey.split('-');
+
+  if (!month || !day) {
+    return dateKey;
+  }
+
+  return `${month}.${day}`;
+}
+
 export default function RankingPage() {
-  const { topThree, rest, isLoading } = useRanking();
+  const [activeTab, setActiveTab] = useState<RankingTab>('today');
+  const { today, yesterday, isLoading, yesterdayDateKey, hasYesterdaySnapshot } = useRanking();
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, []);
+
+  const activeRanking = useMemo(() => {
+    return activeTab === 'today' ? today : yesterday;
+  }, [activeTab, today, yesterday]);
+
+  const isActiveLoading = activeTab === 'today' && isLoading;
+  const yesterdayLabel = formatMonthDay(yesterdayDateKey);
+  const podiumRankOrder = [2, 1, 3] as const;
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -30,7 +51,7 @@ export default function RankingPage() {
     }
   };
 
-  if (isLoading) {
+  if (isActiveLoading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[80vh]">
         <PiSpinnerGapThin className="h-12 w-12 animate-spin text-primary" />
@@ -46,84 +67,131 @@ export default function RankingPage() {
         className="my-4 mx-auto h-14 pointer-events-none select-none"
       />
 
-      <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
-        {topThree.map((booth) => {
-          const rank = booth === topThree[1] ? 1 : booth === topThree[0] ? 2 : 3;
-          const isFirst = rank === 1;
-
-          return (
-            <Link
-              key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
-              className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
-                isFirst
-                  ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
-                  : rank === 2
-                    ? 'border-knu-silver/40 w-[100px] h-[120px]'
-                    : 'border-knu-gold/40 w-[90px] h-[110px]'
-              }`}
-            >
-              <div className="flex items-center justify-center gap-1">
-                <div
-                  className={`relative flex shrink-0 items-center justify-center transition-all ${
-                    isFirst ? 'h-11 w-11' : rank === 2 ? 'h-10 w-10' : 'h-9 w-9'
-                  }`}
-                >
-                  <img src={getRankIcon(rank)} alt="" className="h-full w-full object-contain" />
-                </div>
-                <span
-                  className={`font-semibold text-base-deep/90 ${
-                    isFirst ? 'typo-heading-2' : rank === 2 ? 'typo-heading-3' : 'typo-body-1'
-                  }`}
-                >
-                  {rank}위
-                </span>
-              </div>
-
-              <p className="text-center typo-body-1 font-medium line-clamp-2 text-base-deep">
-                {booth.name}
-              </p>
-
-              <div className="flex items-center gap-1 shrink-0 mb-1">
-                <FaStar className="text-secondary-yellow" />
-                <span className="typo-body-3 font-semibold text-base-deep">
-                  {formatLikeCount(booth.likeCount)}
-                </span>
-              </div>
-            </Link>
-          );
-        })}
+      <div className="mb-4 grid grid-cols-2 gap-2 rounded-2xl bg-white/80 p-1">
+        <button
+          type="button"
+          onClick={() => setActiveTab('today')}
+          className={`rounded-xl px-4 py-2.5 typo-body-2 font-semibold transition ${
+            activeTab === 'today'
+              ? 'bg-knu-red text-white shadow-[0_6px_14px_rgba(230,0,0,0.22)]'
+              : 'text-gray-600 hover:bg-knu-red/10'
+          }`}
+        >
+          오늘 랭킹
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('yesterday')}
+          className={`rounded-xl px-4 py-2.5 typo-body-2 font-semibold transition ${
+            activeTab === 'yesterday'
+              ? 'bg-knu-red text-white shadow-[0_6px_14px_rgba(230,0,0,0.22)]'
+              : 'text-gray-600 hover:bg-knu-red/10'
+          }`}
+        >
+          전날 결과 ({yesterdayLabel})
+        </button>
       </div>
 
-      <section className="space-y-3 pb-24">
-        {rest.map((booth, index) => {
-          const rank = index + 4;
-          return (
-            <Link
-              key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
-              className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
-                  <img src={FaceFillSvg} alt="" className="absolute inset-0 h-full w-full" />
-                  <span className="relative z-10 top-0.5 text-center font-medium text-gray-500 typo-caption">
-                    {rank}
-                  </span>
-                </div>
-                <p className="truncate typo-body-2 font-medium text-base-deep">{booth.name}</p>
-              </div>
+      {activeTab === 'yesterday' && (
+        <p className="mb-3 px-1 typo-caption text-text-muted">
+          {hasYesterdaySnapshot
+            ? `${yesterdayLabel} 기준 저장된 랭킹 결과예요.`
+            : '전날 결과 데이터가 아직 저장되지 않았어요.'}
+        </p>
+      )}
 
-              <div className="flex items-center gap-1 shrink-0">
-                <FaStar className="text-secondary-yellow" />
-                <span className="typo-body-3 font-semibold text-base-deep">
-                  {booth.likeCount.toLocaleString()}
-                </span>
-              </div>
-            </Link>
-          );
-        })}
-      </section>
+      {activeRanking.topThree.length === 0 && activeRanking.rest.length === 0 ? (
+        <div className="rounded-2xl border border-knu-silver/50 bg-white px-4 py-10 text-center text-sm text-text-muted">
+          {activeTab === 'today'
+            ? '아직 집계된 랭킹 데이터가 없습니다.'
+            : '전날 결과를 불러오지 못했어요. 이 브라우저에 저장된 데이터가 없습니다.'}
+        </div>
+      ) : (
+        <>
+          <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
+            {activeRanking.topThree.map((booth, index) => {
+              const rank = podiumRankOrder[index] ?? index + 1;
+              const isFirst = rank === 1;
+
+              return (
+                <Link
+                  key={booth.boothId}
+                  to={`/booths/${booth.boothId}`}
+                  className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
+                    isFirst
+                      ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
+                      : rank === 2
+                        ? 'border-knu-silver/40 w-[100px] h-[120px]'
+                        : 'border-knu-gold/40 w-[90px] h-[110px]'
+                  }`}
+                >
+                  <div className="flex items-center justify-center gap-1">
+                    <div
+                      className={`relative flex shrink-0 items-center justify-center transition-all ${
+                        isFirst ? 'h-11 w-11' : rank === 2 ? 'h-10 w-10' : 'h-9 w-9'
+                      }`}
+                    >
+                      <img
+                        src={getRankIcon(rank)}
+                        alt=""
+                        className="h-full w-full object-contain"
+                      />
+                    </div>
+                    <span
+                      className={`font-semibold text-base-deep/90 ${
+                        isFirst ? 'typo-heading-2' : rank === 2 ? 'typo-heading-3' : 'typo-body-1'
+                      }`}
+                    >
+                      {rank}위
+                    </span>
+                  </div>
+
+                  <p className="text-center typo-body-1 font-medium line-clamp-2 text-base-deep">
+                    {booth.name}
+                  </p>
+
+                  <div className="flex items-center gap-1 shrink-0 mb-1">
+                    <FaStar className="text-secondary-yellow" />
+                    <span className="typo-body-3 font-semibold text-base-deep">
+                      {formatLikeCount(booth.likeCount)}
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          <section className="space-y-3 pb-24">
+            {activeRanking.rest.map((booth, index) => {
+              const rank = index + 4;
+              return (
+                <Link
+                  key={booth.boothId}
+                  to={`/booths/${booth.boothId}`}
+                  className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                      <img src={FaceFillSvg} alt="" className="absolute inset-0 h-full w-full" />
+                      <span className="relative z-10 top-0.5 text-center font-medium text-gray-500 typo-caption">
+                        {rank}
+                      </span>
+                    </div>
+                    <p className="truncate typo-body-2 font-medium text-base-deep">{booth.name}</p>
+                  </div>
+
+                  <div className="flex items-center gap-1 shrink-0">
+                    <FaStar className="text-secondary-yellow" />
+                    <span className="typo-body-3 font-semibold text-base-deep">
+                      {booth.likeCount.toLocaleString()}
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -83,14 +83,6 @@ export default function RankingPage() {
         alt="지금 뜨는 동아리"
         className="my-4 mx-auto h-14 pointer-events-none select-none"
       />
-      <button
-        type="button"
-        onClick={() => setIsPopupOpenedByButton(true)}
-        disabled={!hasYesterdayTop3 && !isYesterdayTop3Loading}
-        className="mb-3 w-full rounded-xl border border-knu-silver/70 bg-white px-4 py-2.5 typo-body-2 font-semibold text-base-deep transition enabled:hover:border-knu-red/35 enabled:hover:bg-knu-red/5 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        어제 TOP3 관심 동아리 보기
-      </button>
 
       <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
         {topThree.map((booth) => {
@@ -170,6 +162,19 @@ export default function RankingPage() {
           );
         })}
       </section>
+
+      {(hasYesterdayTop3 || isYesterdayTop3Loading) && (
+        <button
+          type="button"
+          onClick={() => setIsPopupOpenedByButton(true)}
+          disabled={!hasYesterdayTop3 && isYesterdayTop3Loading}
+          aria-label="어제 TOP3 팝업 열기"
+          className="fixed bottom-[calc(88px+env(safe-area-inset-bottom))] right-5 z-40 inline-flex h-12 items-center justify-center gap-1 rounded-full bg-primary px-4 text-white shadow-[0_10px_22px_rgba(230,0,0,0.28)] transition hover:brightness-95 active:scale-95 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          <FaStar className="h-4 w-4" />
+          <span className="typo-body-3 font-semibold">어제 TOP3</span>
+        </button>
+      )}
 
       {isYesterdayPopupOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-5">

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -167,15 +167,17 @@ export default function RankingPage() {
         })}
       </section>
 
-      <button
-        type="button"
-        onClick={() => setIsPopupOpenedByButton(true)}
-        aria-label="어제 TOP3 팝업 열기"
-        className="fixed bottom-[calc(88px+env(safe-area-inset-bottom))] right-5 z-40 inline-flex h-12 items-center justify-center gap-1 rounded-full bg-primary px-4 text-white shadow-[0_10px_22px_rgba(230,0,0,0.28)] transition hover:brightness-95 active:scale-95"
-      >
-        <FaStar className="h-4 w-4" />
-        <span className="typo-body-3 font-semibold">어제 TOP3</span>
-      </button>
+      <div className="pointer-events-none fixed left-1/2 bottom-[calc(88px+env(safe-area-inset-bottom))] z-40 flex w-full max-w-[700px] -translate-x-1/2 justify-end px-5">
+        <button
+          type="button"
+          onClick={() => setIsPopupOpenedByButton(true)}
+          aria-label="어제 TOP3 팝업 열기"
+          className="pointer-events-auto inline-flex h-12 items-center justify-center gap-1 rounded-full bg-primary px-4 text-white shadow-[0_10px_22px_rgba(230,0,0,0.28)] transition hover:brightness-95 active:scale-95"
+        >
+          <FaStar className="h-4 w-4" />
+          <span className="typo-body-3 font-semibold">어제 TOP3</span>
+        </button>
+      </div>
 
       {isYesterdayPopupOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-5">

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { PiSpinnerGapThin } from 'react-icons/pi';
 import { FaStar } from 'react-icons/fa';
@@ -10,33 +10,12 @@ import FaceSilverSvg from '@/assets/face-silver.svg';
 import FaceBronzeSvg from '@/assets/face-bronze.svg';
 import { formatLikeCount } from '@/lib/count';
 
-type RankingTab = 'today' | 'yesterday';
-
-function formatMonthDay(dateKey: string): string {
-  const [, month, day] = dateKey.split('-');
-
-  if (!month || !day) {
-    return dateKey;
-  }
-
-  return `${month}.${day}`;
-}
-
 export default function RankingPage() {
-  const [activeTab, setActiveTab] = useState<RankingTab>('today');
-  const { today, yesterday, isLoading, yesterdayDateKey, hasYesterdaySnapshot } = useRanking();
+  const { topThree, rest, isLoading } = useRanking();
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, []);
-
-  const activeRanking = useMemo(() => {
-    return activeTab === 'today' ? today : yesterday;
-  }, [activeTab, today, yesterday]);
-
-  const isActiveLoading = activeTab === 'today' && isLoading;
-  const yesterdayLabel = formatMonthDay(yesterdayDateKey);
-  const podiumRankOrder = [2, 1, 3] as const;
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -51,7 +30,7 @@ export default function RankingPage() {
     }
   };
 
-  if (isActiveLoading) {
+  if (isLoading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[80vh]">
         <PiSpinnerGapThin className="h-12 w-12 animate-spin text-primary" />
@@ -67,131 +46,84 @@ export default function RankingPage() {
         className="my-4 mx-auto h-14 pointer-events-none select-none"
       />
 
-      <div className="mb-4 grid grid-cols-2 gap-2 rounded-2xl bg-white/80 p-1">
-        <button
-          type="button"
-          onClick={() => setActiveTab('today')}
-          className={`rounded-xl px-4 py-2.5 typo-body-2 font-semibold transition ${
-            activeTab === 'today'
-              ? 'bg-knu-red text-white shadow-[0_6px_14px_rgba(230,0,0,0.22)]'
-              : 'text-gray-600 hover:bg-knu-red/10'
-          }`}
-        >
-          오늘 랭킹
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab('yesterday')}
-          className={`rounded-xl px-4 py-2.5 typo-body-2 font-semibold transition ${
-            activeTab === 'yesterday'
-              ? 'bg-knu-red text-white shadow-[0_6px_14px_rgba(230,0,0,0.22)]'
-              : 'text-gray-600 hover:bg-knu-red/10'
-          }`}
-        >
-          전날 결과 ({yesterdayLabel})
-        </button>
-      </div>
+      <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
+        {topThree.map((booth) => {
+          const rank = booth === topThree[1] ? 1 : booth === topThree[0] ? 2 : 3;
+          const isFirst = rank === 1;
 
-      {activeTab === 'yesterday' && (
-        <p className="mb-3 px-1 typo-caption text-text-muted">
-          {hasYesterdaySnapshot
-            ? `${yesterdayLabel} 기준 저장된 랭킹 결과예요.`
-            : '전날 결과 데이터가 아직 저장되지 않았어요.'}
-        </p>
-      )}
-
-      {activeRanking.topThree.length === 0 && activeRanking.rest.length === 0 ? (
-        <div className="rounded-2xl border border-knu-silver/50 bg-white px-4 py-10 text-center text-sm text-text-muted">
-          {activeTab === 'today'
-            ? '아직 집계된 랭킹 데이터가 없습니다.'
-            : '전날 결과를 불러오지 못했어요. 이 브라우저에 저장된 데이터가 없습니다.'}
-        </div>
-      ) : (
-        <>
-          <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
-            {activeRanking.topThree.map((booth, index) => {
-              const rank = podiumRankOrder[index] ?? index + 1;
-              const isFirst = rank === 1;
-
-              return (
-                <Link
-                  key={booth.boothId}
-                  to={`/booths/${booth.boothId}`}
-                  className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
-                    isFirst
-                      ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
-                      : rank === 2
-                        ? 'border-knu-silver/40 w-[100px] h-[120px]'
-                        : 'border-knu-gold/40 w-[90px] h-[110px]'
+          return (
+            <Link
+              key={booth.boothId}
+              to={`/booths/${booth.boothId}`}
+              className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
+                isFirst
+                  ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
+                  : rank === 2
+                    ? 'border-knu-silver/40 w-[100px] h-[120px]'
+                    : 'border-knu-gold/40 w-[90px] h-[110px]'
+              }`}
+            >
+              <div className="flex items-center justify-center gap-1">
+                <div
+                  className={`relative flex shrink-0 items-center justify-center transition-all ${
+                    isFirst ? 'h-11 w-11' : rank === 2 ? 'h-10 w-10' : 'h-9 w-9'
                   }`}
                 >
-                  <div className="flex items-center justify-center gap-1">
-                    <div
-                      className={`relative flex shrink-0 items-center justify-center transition-all ${
-                        isFirst ? 'h-11 w-11' : rank === 2 ? 'h-10 w-10' : 'h-9 w-9'
-                      }`}
-                    >
-                      <img
-                        src={getRankIcon(rank)}
-                        alt=""
-                        className="h-full w-full object-contain"
-                      />
-                    </div>
-                    <span
-                      className={`font-semibold text-base-deep/90 ${
-                        isFirst ? 'typo-heading-2' : rank === 2 ? 'typo-heading-3' : 'typo-body-1'
-                      }`}
-                    >
-                      {rank}위
-                    </span>
-                  </div>
-
-                  <p className="text-center typo-body-1 font-medium line-clamp-2 text-base-deep">
-                    {booth.name}
-                  </p>
-
-                  <div className="flex items-center gap-1 shrink-0 mb-1">
-                    <FaStar className="text-secondary-yellow" />
-                    <span className="typo-body-3 font-semibold text-base-deep">
-                      {formatLikeCount(booth.likeCount)}
-                    </span>
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-
-          <section className="space-y-3 pb-24">
-            {activeRanking.rest.map((booth, index) => {
-              const rank = index + 4;
-              return (
-                <Link
-                  key={booth.boothId}
-                  to={`/booths/${booth.boothId}`}
-                  className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
+                  <img src={getRankIcon(rank)} alt="" className="h-full w-full object-contain" />
+                </div>
+                <span
+                  className={`font-semibold text-base-deep/90 ${
+                    isFirst ? 'typo-heading-2' : rank === 2 ? 'typo-heading-3' : 'typo-body-1'
+                  }`}
                 >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
-                      <img src={FaceFillSvg} alt="" className="absolute inset-0 h-full w-full" />
-                      <span className="relative z-10 top-0.5 text-center font-medium text-gray-500 typo-caption">
-                        {rank}
-                      </span>
-                    </div>
-                    <p className="truncate typo-body-2 font-medium text-base-deep">{booth.name}</p>
-                  </div>
+                  {rank}위
+                </span>
+              </div>
 
-                  <div className="flex items-center gap-1 shrink-0">
-                    <FaStar className="text-secondary-yellow" />
-                    <span className="typo-body-3 font-semibold text-base-deep">
-                      {booth.likeCount.toLocaleString()}
-                    </span>
-                  </div>
-                </Link>
-              );
-            })}
-          </section>
-        </>
-      )}
+              <p className="text-center typo-body-1 font-medium line-clamp-2 text-base-deep">
+                {booth.name}
+              </p>
+
+              <div className="flex items-center gap-1 shrink-0 mb-1">
+                <FaStar className="text-secondary-yellow" />
+                <span className="typo-body-3 font-semibold text-base-deep">
+                  {formatLikeCount(booth.likeCount)}
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      <section className="space-y-3 pb-24">
+        {rest.map((booth, index) => {
+          const rank = index + 4;
+          return (
+            <Link
+              key={booth.boothId}
+              to={`/booths/${booth.boothId}`}
+              className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                  <img src={FaceFillSvg} alt="" className="absolute inset-0 h-full w-full" />
+                  <span className="relative z-10 top-0.5 text-center font-medium text-gray-500 typo-caption">
+                    {rank}
+                  </span>
+                </div>
+                <p className="truncate typo-body-2 font-medium text-base-deep">{booth.name}</p>
+              </div>
+
+              <div className="flex items-center gap-1 shrink-0">
+                <FaStar className="text-secondary-yellow" />
+                <span className="typo-body-3 font-semibold text-base-deep">
+                  {booth.likeCount.toLocaleString()}
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </section>
     </div>
   );
 }

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { PiSpinnerGapThin } from 'react-icons/pi';
 import { FaStar } from 'react-icons/fa';
+import { FiX } from 'react-icons/fi';
 import { useRanking } from '@/hooks/useRanking';
+import { useYesterdayBoothTop3 } from '@/hooks/useYesterdayBoothTop3';
 import FaceFillSvg from '@/assets/face-fill.svg';
 import RankingHeaderSvg from '@/assets/ranking-header.svg';
 import FaceGoldSvg from '@/assets/face-gold.svg';
@@ -10,12 +12,34 @@ import FaceSilverSvg from '@/assets/face-silver.svg';
 import FaceBronzeSvg from '@/assets/face-bronze.svg';
 import { formatLikeCount } from '@/lib/count';
 
+function getTodayKey() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function RankingPage() {
   const { topThree, rest, isLoading } = useRanking();
+  const { data: yesterdayTop3, isLoading: isYesterdayTop3Loading } = useYesterdayBoothTop3();
+
+  const dismissStorageKey = useMemo(() => `ranking-yesterday-top3-dismissed-${getTodayKey()}`, []);
+
+  const [isDismissedToday, setIsDismissedToday] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(dismissStorageKey) === '1';
+  });
+  const [isPopupClosed, setIsPopupClosed] = useState(false);
+  const [isPopupOpenedByButton, setIsPopupOpenedByButton] = useState(false);
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, []);
+
+  const hasYesterdayTop3 = yesterdayTop3.length > 0;
+  const isAutoPopupOpen = hasYesterdayTop3 && !isDismissedToday && !isPopupClosed;
+  const isYesterdayPopupOpen = isPopupOpenedByButton || isAutoPopupOpen;
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -28,6 +52,20 @@ export default function RankingPage() {
       default:
         return FaceFillSvg;
     }
+  };
+
+  const handleCloseYesterdayPopup = () => {
+    setIsPopupOpenedByButton(false);
+    setIsPopupClosed(true);
+  };
+
+  const handleDismissToday = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(dismissStorageKey, '1');
+    }
+    setIsDismissedToday(true);
+    setIsPopupOpenedByButton(false);
+    setIsPopupClosed(true);
   };
 
   if (isLoading) {
@@ -45,6 +83,14 @@ export default function RankingPage() {
         alt="지금 뜨는 동아리"
         className="my-4 mx-auto h-14 pointer-events-none select-none"
       />
+      <button
+        type="button"
+        onClick={() => setIsPopupOpenedByButton(true)}
+        disabled={!hasYesterdayTop3 && !isYesterdayTop3Loading}
+        className="mb-3 w-full rounded-xl border border-knu-silver/70 bg-white px-4 py-2.5 typo-body-2 font-semibold text-base-deep transition enabled:hover:border-knu-red/35 enabled:hover:bg-knu-red/5 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        어제 TOP3 관심 동아리 보기
+      </button>
 
       <div className="flex items-end justify-center gap-2 px-1 mb-3 relative z-20">
         {topThree.map((booth) => {
@@ -124,6 +170,77 @@ export default function RankingPage() {
           );
         })}
       </section>
+
+      {isYesterdayPopupOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center px-5">
+          <button
+            type="button"
+            aria-label="전날 TOP3 팝업 닫기"
+            className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+            onClick={handleCloseYesterdayPopup}
+          />
+
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-label="어제 TOP3 안내"
+            className="relative w-full max-w-[420px] rounded-3xl bg-white p-5 shadow-[0_20px_50px_rgba(0,0,0,0.2)]"
+          >
+            <button
+              type="button"
+              aria-label="팝업 닫기"
+              onClick={handleCloseYesterdayPopup}
+              className="absolute right-4 top-4 rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            >
+              <FiX className="h-5 w-5" />
+            </button>
+
+            <h2 className="typo-heading-3 text-base-deep">어제 TOP3 관심 동아리였습니다</h2>
+            <p className="mt-1 typo-body-3 text-gray-500">오늘도 많은 참여 부탁드릴게요!</p>
+
+            <div className="mt-4 space-y-2">
+              {yesterdayTop3.map((booth, index) => (
+                <Link
+                  key={booth.boothId}
+                  to={`/booths/${booth.boothId}`}
+                  onClick={handleCloseYesterdayPopup}
+                  className="interactive-transition flex items-center justify-between rounded-2xl border border-knu-silver/60 bg-knu-silver/10 px-4 py-3 hover:border-knu-red/25 hover:bg-knu-red/5"
+                >
+                  <div className="min-w-0">
+                    <p className="typo-body-3 font-semibold text-knu-red">{index + 1}위</p>
+                    <p className="truncate typo-body-2 font-medium text-base-deep">
+                      {booth.boothName}
+                    </p>
+                  </div>
+                  <div className="ml-3 flex items-center gap-1">
+                    <FaStar className="text-secondary-yellow" />
+                    <span className="typo-body-3 font-semibold text-base-deep">
+                      {formatLikeCount(booth.likeCount)}
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            <div className="mt-5 grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={handleDismissToday}
+                className="interactive-transition rounded-xl border border-gray-200 px-3 py-2.5 typo-body-2 font-semibold text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+              >
+                오늘 하루 보지 않기
+              </button>
+              <button
+                type="button"
+                onClick={handleCloseYesterdayPopup}
+                className="interactive-transition rounded-xl bg-primary px-3 py-2.5 typo-body-2 font-semibold text-white hover:brightness-95"
+              >
+                확인
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 랭킹 페이지의 전날 TOP3 노출 방식을 개선했습니다.
- 전날 랭킹 API 경로 변경(`daily/{date}`)을 반영하고, 팝업/플로팅 버튼 UX를 정리했습니다.
- 더블 스타 이벤트 팝업 시간/날짜도 오늘 기준(12:00~14:00)으로 재설정했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #88

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 전날 랭킹 API 연동 경로 변경
  - `GET /api/v1/booths/ranking/daily/{date}` 기반으로 전환
  - API 레이어(`endpoints`, `boothApi`, `apis/index`) 및 전용 훅(`useYesterdayBoothTop3`) 수정
- 랭킹 페이지 전날 TOP3 팝업 UX 개선
  - 어제 TOP3 플로팅 버튼 유지(상시 노출)
  - 팝업 내 로딩/빈 데이터 상태 UI 추가
  - 카드 클릭 시 부스 상세 이동 유지
- 플로팅 버튼 위치 보정
  - PC/모바일 모두 레이아웃 내부 우측 하단에 고정되도록 정렬 수정
- 더블 스타 이벤트 팝업 재설정
  - 이벤트 날짜를 오늘 기준으로 재설정
  - 이벤트 시간 12:00~14:00으로 반영
  - 팝업 시간 텍스트를 상수 기반으로 동기화

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

- 랭킹 페이지 우측 하단 플로팅 버튼 위치 변경 전/후
- 어제 TOP3 팝업 로딩/빈 상태/정상 데이터 상태

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 전날 TOP3 데이터 소스를 프론트 로컬 캐시가 아닌 서버 API로 통일해 데이터 신뢰도를 높였습니다.
- 버튼이 로딩 후 사라지거나 PC에서 레이아웃 밖으로 보이던 UI 이슈를 해결해 접근성을 개선했습니다.
- 이벤트 팝업 시간/날짜를 운영 일정에 맞게 조정해 오노출/오안내를 방지했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- `/ranking/daily/{date}` 응답 필드(`boothId`, `name`, `likeCount`)와 프론트 매핑이 현재 명세와 일치하는지 확인 부탁드립니다.
- 플로팅 버튼 위치가 iOS Safari/Android Chrome에서 동일하게 우측 하단 정렬되는지 확인 부탁드립니다.
