### PR TITLE
[FEAT] 부스 카드 클릭 시 지도 페이지 포커싱으로 이동 로직 변경

### DIFF
--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -102,7 +102,7 @@ function TrendingBooths() {
           return (
             <button
               key={booth.boothId}
-              onClick={() => navigate(`/booths/${booth.boothId}`)}
+              onClick={() => navigate('/map', { state: { selectedBoothId: booth.boothId } })}
               className={`relative flex flex-col w-[120px] py-3 items-center justify-center gap-1 rounded-xl bg-secondary-yellow/10 transition-all active:scale-95`}
             >
               <div className="flex items-center justify-center gap-1">
@@ -123,7 +123,7 @@ function TrendingBooths() {
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        카드를 눌러 동아리 정보를 확인할 수 있어요
+        카드를 눌러 부스 위치를 확인할 수 있어요
       </p>
     </div>
   );
@@ -273,7 +273,7 @@ function TimeTablePreviewCard({
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        카드를 눌러 동아리 위치를 확인할 수 있어요
+        카드를 눌러 부스 위치를 확인할 수 있어요
       </p>
     </>
   );

--- a/src/hooks/useLikeBooth.ts
+++ b/src/hooks/useLikeBooth.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { likeBooth } from '@/apis/modules/boothApi';
 
-const CLIENT_LIKE_COOLDOWN_MS = 1000;
+const CLIENT_LIKE_COOLDOWN_MS = 700;
 
 export function useLikeBooth(boothId: number) {
   const [isPending, setIsPending] = useState(false);

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -96,7 +96,8 @@ export default function RankingPage() {
           return (
             <Link
               key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
+              to="/map"
+              state={{ selectedBoothId: booth.boothId }}
               className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
                 isFirst
                   ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
@@ -143,7 +144,8 @@ export default function RankingPage() {
           return (
             <Link
               key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
+              to="/map"
+              state={{ selectedBoothId: booth.boothId }}
               className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
             >
               <div className="flex items-center gap-3 min-w-0">


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 부스 카드 클릭 시 상세페이지가 아닌 지도 페이지 포커싱으로 이동 로직 변경

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #120 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 부스 카드 클릭 시 상세 페이지 이동 대신 지도 페이지로 이동
- 좋아요 쿨타임 1000ms에서 700ms로 단축

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

-유저들이 상세 페이지에서 좋아요만 누르고 실제 위치 확인이 낮은 문제를 확인하였고(PostHog), 마지막 날인 만큼 탐색보다 방문에 집중할 수 있도록 동선을 변경함
- 좋아요 쿨타임을 0.7초로 단축하여 유저가 느끼는 피드백 속도를 높이고자 함
