### PR TITLE
[Release] 1.3.2 배포

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knu-client",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "packageManager": "pnpm@9.15.3",
   "scripts": {

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -102,7 +102,7 @@ function TrendingBooths() {
           return (
             <button
               key={booth.boothId}
-              onClick={() => navigate(`/booths/${booth.boothId}`)}
+              onClick={() => navigate('/map', { state: { selectedBoothId: booth.boothId } })}
               className={`relative flex flex-col w-[120px] py-3 items-center justify-center gap-1 rounded-xl bg-secondary-yellow/10 transition-all active:scale-95`}
             >
               <div className="flex items-center justify-center gap-1">
@@ -123,7 +123,7 @@ function TrendingBooths() {
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        카드를 눌러 동아리 정보를 확인할 수 있어요
+        카드를 눌러 부스 위치를 확인할 수 있어요
       </p>
     </div>
   );
@@ -273,7 +273,7 @@ function TimeTablePreviewCard({
       </div>
       <p className="ml-1 mt-3 flex gap-1 items-center text-text-muted typo-caption select-none">
         <FiAlertCircle className="h-4 w-4 flex items-baseline text-text-muted" strokeWidth={1.5} />
-        카드를 눌러 동아리 위치를 확인할 수 있어요
+        카드를 눌러 부스 위치를 확인할 수 있어요
       </p>
     </>
   );

--- a/src/components/layouts/DetailLayout.tsx
+++ b/src/components/layouts/DetailLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router-dom';
 
 import BackHeader from '@/components/navigation/BackHeader';
 import BottomTabBar from '@/components/navigation/BottomTabBar';
@@ -9,11 +9,24 @@ type DetailLayoutProps = {
 };
 
 export default function DetailLayout({ title, fallbackPath }: DetailLayoutProps) {
+  const { id } = useParams();
+
+  const dynamicFallback =
+    id && fallbackPath === '/map'
+      ? { pathname: '/map', state: { selectedBoothId: Number(id) } }
+      : fallbackPath;
+
   return (
     <div className="min-h-dvh bg-gray-100 text-knu-gray">
       <div className="mx-auto flex min-h-dvh w-full max-w-[700px] flex-col bg-white">
         <main className="relative flex-1 min-h-0 px-5 pb-[calc(88px+env(safe-area-inset-bottom))]">
-          <BackHeader title={title} fallbackPath={fallbackPath} />
+          <BackHeader
+            title={title}
+            fallbackPath={
+              typeof dynamicFallback === 'string' ? dynamicFallback : dynamicFallback.pathname
+            }
+            state={typeof dynamicFallback !== 'string' ? dynamicFallback.state : undefined}
+          />
           <Outlet />
         </main>
         <BottomTabBar />

--- a/src/components/navigation/BackHeader.tsx
+++ b/src/components/navigation/BackHeader.tsx
@@ -4,17 +4,23 @@ import { useNavigate } from 'react-router-dom';
 type BackHeaderProps = {
   title: string;
   fallbackPath: string;
+  state?: { selectedBoothId: number | undefined };
 };
 
-export default function BackHeader({ title, fallbackPath }: BackHeaderProps) {
+export default function BackHeader({ title, fallbackPath, state }: BackHeaderProps) {
   const navigate = useNavigate();
 
   const handleBack = () => {
-    if (window.history.length > 1) {
-      navigate(-1);
+    if (state) {
+      navigate(fallbackPath, { replace: true, state });
+
       return;
     }
+    if (window.history.length > 1) {
+      navigate(-1);
 
+      return;
+    }
     navigate(fallbackPath, { replace: true });
   };
 

--- a/src/hooks/useLikeBooth.ts
+++ b/src/hooks/useLikeBooth.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { likeBooth } from '@/apis/modules/boothApi';
 
-const CLIENT_LIKE_COOLDOWN_MS = 1000;
+const CLIENT_LIKE_COOLDOWN_MS = 700;
 
 export function useLikeBooth(boothId: number) {
   const [isPending, setIsPending] = useState(false);

--- a/src/pages/BoothDetailPage.tsx
+++ b/src/pages/BoothDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import ImageCarousel from '@/components/ImageCarousel';
 import ApplyButton from '@/components/ApplyButton';
@@ -110,14 +110,7 @@ export default function BoothDetailPage() {
           </p>
         </div>
       </div>
-      <div className="flex gap-3 mb-10">
-        <Link
-          to="/map"
-          state={{ selectedBoothId: booth.id }}
-          className="flex-1 flex items-center justify-center bg-gray-100 rounded-full text-base-deep py-3 mb-6 typo-body-1 cursor-pointer transition-all hover:scale-[1.01] hover:brightness-95 active:scale-[0.98]"
-        >
-          위치보기
-        </Link>
+      <div className="flex mb-10">
         {!isSpecialDivision && booth.applyLink && (
           <div className="flex-1">
             <ApplyButton url={booth.applyLink} />

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -96,7 +96,8 @@ export default function RankingPage() {
           return (
             <Link
               key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
+              to="/map"
+              state={{ selectedBoothId: booth.boothId }}
               className={`relative flex flex-col items-center justify-center gap-1 rounded-lg py-2 bg-white border ${
                 isFirst
                   ? 'border-secondary-yellow z-10 w-[120px] h-[140px]'
@@ -143,7 +144,8 @@ export default function RankingPage() {
           return (
             <Link
               key={booth.boothId}
-              to={`/booths/${booth.boothId}`}
+              to="/map"
+              state={{ selectedBoothId: booth.boothId }}
               className="interactive-transition flex items-center justify-between rounded-2xl px-5 py-4 bg-white border border-primary/10"
             >
               <div className="flex items-center gap-3 min-w-0">

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -223,7 +223,8 @@ export default function RankingPage() {
                 {yesterdayTop3.map((booth, index) => (
                   <Link
                     key={booth.boothId}
-                    to={`/booths/${booth.boothId}`}
+                    to="/map"
+                    state={{ selectedBoothId: booth.boothId }}
                     onClick={handleCloseYesterdayPopup}
                     className="interactive-transition flex items-center justify-between rounded-2xl border border-knu-silver/60 bg-knu-silver/10 px-4 py-3 hover:border-knu-red/25 hover:bg-knu-red/5"
                   >


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 랭킹 및 리스트 부스 카드 클릭 시 지도 포커싱 로직 적용 및 좋아요 쿨타임 최적화 (v1.4.2)


## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 부스 카드 클릭 동작 변경: 상세 페이지 이동 대신 지도( /map)로 즉시 이동하며 해당 부스 위치를 포커싱하도록 변경
- 좋아요 쿨타임 단축: CLIENT_LIKE_COOLDOWN_MS를 1.0s에서 0.7s로 하향 조정

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 데이터 기반 UX 개선: 유저가 앱 내에서 실제 현장 행동으로 전환되는 과정의 마찰을 줄이기 위해 동선을 개편함

- 마지막 날 화력 집중: 축제 마지막 날인 만큼 유저의 참여 속도에 맞춰 좋아요 쿨타임을 0.7초로 단축해 유저에게 더 빠른 피드백을 제공하여 현장 분위기를 고조시키고 서비스 만족도를 높이고자 함
